### PR TITLE
자격증 조회 관련 예외 처리 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,11 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+  	testImplementation 'com.h2database:h2'	// TODO 최지희: 임시
 
 	// querydsl
     implementation("com.querydsl:querydsl-jpa:5.1.0:jakarta")

--- a/src/main/java/quartet/server/api/certification/CertificationController.java
+++ b/src/main/java/quartet/server/api/certification/CertificationController.java
@@ -44,13 +44,12 @@ public class CertificationController {
     @GetMapping("")
     public ApiResponse<Page<CertificationsByCategoryRes>>  getAllCertificationByCategory(
             @RequestParam long categoryId,
-            @RequestParam boolean isSubCategory,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "15") int pageSize
     ){
         PageRequest pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Order.asc("id")));
         Page<CertificationsByCategoryRes> certificationList = certificationService.getAllCertificationsByCategory(
-                categoryId, isSubCategory, pageable);
+                categoryId, pageable);
         return ApiResponse.success(OK,certificationList);
     }
 }

--- a/src/main/java/quartet/server/api/certification/CertificationService.java
+++ b/src/main/java/quartet/server/api/certification/CertificationService.java
@@ -13,6 +13,8 @@ import quartet.server.domain.category.model.Category;
 import quartet.server.domain.category.repository.CategoryRepository;
 import quartet.server.domain.certification.repository.*;
 import quartet.server.domain.certification.exception.CertificationNotFoundException;
+import quartet.server.domain.category.exception.CategoryNotFoundException;
+import quartet.server.domain.category.exception.SubCategoryNotFoundException;
 
 import java.util.List;
 
@@ -37,10 +39,14 @@ public class CertificationService {
 
     @Transactional(readOnly = true)
     public Page<CertificationsByCategoryRes> getAllCertificationsByCategory(
-            long categoryId, boolean isSubCategory, Pageable pageable){
+            long categoryId,Pageable pageable){
+
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(CategoryNotFoundException::new);
 
         // 대분류 카테고리가 주어질 경우 -> 디폴트 서브 카테고리로 변경한 후, 검색
-        if (!isSubCategory) categoryId = certificationQueryRepository.getDefaultSubCategoryId(categoryId);
+        if (category.getParentCategory() == null) categoryId = certificationQueryRepository.getDefaultSubCategoryId(categoryId)
+                .orElseThrow(SubCategoryNotFoundException::new);
 
         return certificationQueryRepository.findAllCertificationByCategory(categoryId,pageable);
 

--- a/src/main/java/quartet/server/api/certification/CertificationService.java
+++ b/src/main/java/quartet/server/api/certification/CertificationService.java
@@ -12,6 +12,7 @@ import quartet.server.api.certification.query.CertificationQueryRepository;
 import quartet.server.domain.category.model.Category;
 import quartet.server.domain.category.repository.CategoryRepository;
 import quartet.server.domain.certification.repository.*;
+import quartet.server.domain.certification.exception.CertificationNotFoundException;
 
 import java.util.List;
 
@@ -30,7 +31,8 @@ public class CertificationService {
 
     @Transactional(readOnly = true)
     public CertificationRes getCertification(long certificationId) {
-        return certificationQueryRepository.getCertification(certificationId);
+        return certificationQueryRepository.getCertification(certificationId)
+                 .orElseThrow(CertificationNotFoundException::new);
     }
 
     @Transactional(readOnly = true)
@@ -41,9 +43,9 @@ public class CertificationService {
         if (!isSubCategory) categoryId = certificationQueryRepository.getDefaultSubCategoryId(categoryId);
 
         return certificationQueryRepository.findAllCertificationByCategory(categoryId,pageable);
+
     }
 
-    // TODO 최지희 - 리뷰
     // 소분류 카테고리 조회
     @Transactional(readOnly = true)
     public List<CertificationCategoriesRes> getCategories(long parentId){
@@ -54,7 +56,6 @@ public class CertificationService {
                 .toList();
     }
 
-    // TODO 최지희 - 리뷰
     // 대분류 카테고리 조회
     @Transactional(readOnly = true)
     public List<CertificationCategoriesRes> getCategories(boolean isDefault){

--- a/src/main/java/quartet/server/api/certification/query/CertificationQueryRepository.java
+++ b/src/main/java/quartet/server/api/certification/query/CertificationQueryRepository.java
@@ -28,14 +28,14 @@ import static com.querydsl.core.types.dsl.Expressions.cases;
 public class CertificationQueryRepository {
     private final JPAQueryFactory queryFactory;
 
-    public CertificationRes getCertification(Long certificationId) {
+    public Optional<CertificationRes> getCertification(Long certificationId) {
         QCertification certification = QCertification.certification;
         QAuthority authority = QAuthority.authority;
         QCertificationDescription description = QCertificationDescription.certificationDescription;
         QCertificationSchedule schedule = QCertificationSchedule.certificationSchedule;
         QCertificationExamDetail examDetail = QCertificationExamDetail.certificationExamDetail;
 
-        Map<Long, CertificationRes> transformResult =
+        Map<Long, CertificationRes> result =
                 queryFactory
                     .from(certification)
                     .leftJoin(certification.authority, authority)
@@ -71,7 +71,7 @@ public class CertificationQueryRepository {
                         )
                     ));
 
-        return transformResult.get(certificationId);
+        return Optional.ofNullable(result.get(certificationId));
     }
 
     public long getDefaultSubCategoryId(long categoryId){

--- a/src/main/java/quartet/server/api/certification/query/CertificationQueryRepository.java
+++ b/src/main/java/quartet/server/api/certification/query/CertificationQueryRepository.java
@@ -10,7 +10,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 import quartet.server.api.certification.dto.response.*;
-import quartet.server.domain.category.exception.CategoryNotFoundException;
 import quartet.server.domain.category.model.QCategory;
 import quartet.server.domain.certification.model.*;
 import quartet.server.domain.certification.type.ExamType;
@@ -74,17 +73,15 @@ public class CertificationQueryRepository {
         return Optional.ofNullable(result.get(certificationId));
     }
 
-    public long getDefaultSubCategoryId(long categoryId){
+    public Optional<Long> getDefaultSubCategoryId(long categoryId){
         QCategory category = QCategory.category;
 
         // TODO 최지희: default 서브 카테고리 선정 기준 논의 필요
-        return Optional.ofNullable(
-                        queryFactory
-                        .select(category.id)
-                        .from(category)
-                        .where(category.parentCategory.id.eq(categoryId))
-                        .fetchFirst())
-                .orElseThrow(CategoryNotFoundException::new);
+        return Optional.ofNullable(queryFactory
+                    .select(category.id)
+                    .from(category)
+                    .where(category.parentCategory.id.eq(categoryId))
+                    .fetchFirst());
     }
 
     private JPAQuery<Long> findAllCertificationsByCategoryBaseQuery(long subCategoryId){

--- a/src/main/java/quartet/server/core/code/CategoryErrorCode.java
+++ b/src/main/java/quartet/server/core/code/CategoryErrorCode.java
@@ -7,8 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum CategoryErrorCode implements ResponseCode{
-    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다.");
-
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다."),
+    SUB_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 소카테고리가 없습니다.");
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/quartet/server/core/code/CertificationErrorCode.java
+++ b/src/main/java/quartet/server/core/code/CertificationErrorCode.java
@@ -1,0 +1,13 @@
+package quartet.server.core.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CertificationErrorCode implements ResponseCode {
+    CERTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 자격증입니다.");
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/quartet/server/domain/category/exception/SubCategoryNotFoundException.java
+++ b/src/main/java/quartet/server/domain/category/exception/SubCategoryNotFoundException.java
@@ -1,0 +1,7 @@
+package quartet.server.domain.category.exception;
+
+import quartet.server.core.code.CategoryErrorCode;
+
+public class SubCategoryNotFoundException extends CategoryException{
+    public SubCategoryNotFoundException(){super(CategoryErrorCode.SUB_CATEGORY_NOT_FOUND);}
+}

--- a/src/main/java/quartet/server/domain/certification/exception/CertificationException.java
+++ b/src/main/java/quartet/server/domain/certification/exception/CertificationException.java
@@ -1,0 +1,8 @@
+package quartet.server.domain.certification.exception;
+
+import quartet.server.core.code.ResponseCode;
+import quartet.server.core.exception.BaseException;
+
+public class CertificationException extends BaseException {
+    protected CertificationException (ResponseCode errorCode){super(errorCode);}
+}

--- a/src/main/java/quartet/server/domain/certification/exception/CertificationNotFoundException.java
+++ b/src/main/java/quartet/server/domain/certification/exception/CertificationNotFoundException.java
@@ -1,0 +1,7 @@
+package quartet.server.domain.certification.exception;
+
+import quartet.server.core.code.CertificationErrorCode;
+
+public class CertificationNotFoundException extends CertificationException{
+    public CertificationNotFoundException(){super(CertificationErrorCode.CERTIFICATION_NOT_FOUND);}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,4 @@
 spring:
   profiles:
     active:
-      - local
+      - develop

--- a/src/test/java/quartet/server/api/certification/CertificationControllerTest.java
+++ b/src/test/java/quartet/server/api/certification/CertificationControllerTest.java
@@ -12,8 +12,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import quartet.server.api.certification.dto.response.CertificationCategoriesRes;
 import quartet.server.api.certification.dto.response.CertificationRes;
 import quartet.server.api.certification.dto.response.CertificationsByCategoryRes;
-import quartet.server.utils.fixture.CertificationFixture;
-import quartet.server.utils.fixture.CertificationCategoryFixture;
+import quartet.server.utils.fixture.Certification.CertificationFixture;
+import quartet.server.utils.fixture.Certification.CertificationCategoryFixture;
 import java.util.*;
 import static org.mockito.Mockito.*;
 import static org.hamcrest.Matchers.hasSize;
@@ -111,7 +111,6 @@ public class CertificationControllerTest {
 
         when(certificationService.getAllCertificationsByCategory(
                 eq(categoryId),
-                eq(true),
                 any(PageRequest.class)
         )).thenReturn(certificationPage);
 

--- a/src/test/java/quartet/server/api/certification/CertificationServiceTest.java
+++ b/src/test/java/quartet/server/api/certification/CertificationServiceTest.java
@@ -16,11 +16,14 @@ import quartet.server.api.certification.dto.response.CertificationsByCategoryRes
 import quartet.server.api.certification.query.CertificationQueryRepository;
 import quartet.server.domain.category.model.Category;
 import quartet.server.domain.category.repository.CategoryRepository;
+import quartet.server.domain.certification.exception.CertificationNotFoundException;
 import quartet.server.utils.fixture.CertificationFixture;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 
@@ -191,8 +194,7 @@ class CertificationServiceTest {
             // given
             long certificationId = 1L;
             CertificationRes certificationRes = CertificationFixture.certificationRes(certificationId);
-
-            when(certificationQueryRepository.getCertification(certificationId)).thenReturn(certificationRes);
+            when(certificationQueryRepository.getCertification(certificationId)).thenReturn(Optional.of(certificationRes));
 
             // when
             CertificationRes result = certificationService.getCertification(certificationId);
@@ -201,6 +203,17 @@ class CertificationServiceTest {
             assertThat(result).isEqualTo(certificationRes);
             verify(certificationQueryRepository, times(1)).getCertification(certificationId);
 
+        }
+
+        @Test
+        public void fail_notFoundCertification(){
+            // given
+            long certificationId = 99L;
+            when(certificationQueryRepository.getCertification(certificationId)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThrows(CertificationNotFoundException.class, () -> {certificationService.getCertification(certificationId);});
+            verify(certificationQueryRepository, times(1)).getCertification(certificationId);
         }
     }
 

--- a/src/test/java/quartet/server/api/certification/CertificationServiceTest.java
+++ b/src/test/java/quartet/server/api/certification/CertificationServiceTest.java
@@ -14,10 +14,14 @@ import quartet.server.api.certification.dto.response.CertificationCategoriesRes;
 import quartet.server.api.certification.dto.response.CertificationRes;
 import quartet.server.api.certification.dto.response.CertificationsByCategoryRes;
 import quartet.server.api.certification.query.CertificationQueryRepository;
+import quartet.server.domain.category.exception.CategoryNotFoundException;
+import quartet.server.domain.category.exception.SubCategoryNotFoundException;
 import quartet.server.domain.category.model.Category;
 import quartet.server.domain.category.repository.CategoryRepository;
 import quartet.server.domain.certification.exception.CertificationNotFoundException;
-import quartet.server.utils.fixture.CertificationFixture;
+import quartet.server.utils.fixture.Certification.CertificationCategoryFixture;
+import quartet.server.utils.fixture.Certification.CertificationFixture;
+import quartet.server.utils.fixture.Pageable.PageableFixture;
 
 import java.util.List;
 import java.util.Optional;
@@ -136,24 +140,25 @@ class CertificationServiceTest {
 
     @Nested
     class getAllCertificationByCategory{
-        /* 특정 대분류 카테고리에 접속했을때, 디폴트로 보여지는 서브 카테고리에 대한 자격증 */
+        /* 특정 대분류 카테고리 id -> 디폴트 소분류에 대한 자격증 조회(모든 자격증은 소분류 id만 참조합니다) */
         @Test
         void success_withParentCategoryId(){
             // given
-            boolean isSubCategory = false;
             long categoryId = 1L;
             long subCategoryId = 2L;
-            Pageable pageable = PageRequest.of(0, 10);
+            Pageable pageable = PageableFixture.pageable();
+            Category category = CertificationCategoryFixture.parentCategory();
             List<CertificationsByCategoryRes> certificationList = CertificationFixture.certificationsByCategoryRes();
             Page<CertificationsByCategoryRes> certificationPage = new PageImpl<>(certificationList);
 
-            when(certificationQueryRepository.getDefaultSubCategoryId(categoryId)).thenReturn(subCategoryId);
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+            when(certificationQueryRepository.getDefaultSubCategoryId(categoryId)).thenReturn(Optional.of(subCategoryId));
             when(certificationQueryRepository.findAllCertificationByCategory(subCategoryId,pageable))
                     .thenReturn(certificationPage);
 
             // when
             Page<CertificationsByCategoryRes> result = certificationService.getAllCertificationsByCategory(
-                    categoryId, isSubCategory, pageable);
+                    categoryId, pageable);
 
             // then
             assertThat(result).isEqualTo(certificationPage);
@@ -162,27 +167,56 @@ class CertificationServiceTest {
             verify(certificationQueryRepository, times(1)).findAllCertificationByCategory(subCategoryId, pageable);
         }
 
-        /* 특정 서브 카테고리를 선택했을때 조회되는 자격증 */
+        /* 특정 소분류 카테고리 id로 자격증 조회 */
         @Test
         void success_withSubCategoryId(){
             // given
-            boolean isSubCategory = true;
             long categoryId = 1L;
-            Pageable pageable = PageRequest.of(0, 10);
+            Pageable pageable = PageableFixture.pageable();
+            Category category = CertificationCategoryFixture.subCategory();
             List<CertificationsByCategoryRes> certificationList = CertificationFixture.certificationsByCategoryRes();
             Page<CertificationsByCategoryRes> certificationPage = new PageImpl<>(certificationList);
 
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
             when(certificationQueryRepository.findAllCertificationByCategory(categoryId,pageable))
                     .thenReturn(certificationPage);
 
             // when
             Page<CertificationsByCategoryRes> result = certificationService.getAllCertificationsByCategory(
-                    categoryId, isSubCategory, pageable);
+                    categoryId, pageable);
 
             // then
             assertThat(result).isEqualTo(certificationPage);
             verify(certificationQueryRepository, never()).getDefaultSubCategoryId(anyLong());
             verify(certificationQueryRepository, times(1)).findAllCertificationByCategory(categoryId, pageable);
+        }
+
+        @Test
+        void fail_notFoundCategoryException(){
+            // given
+            long categoryId = 1L;
+            Pageable pageable = PageableFixture.pageable();
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThrows(CategoryNotFoundException.class, () -> {certificationService.getAllCertificationsByCategory(categoryId, pageable);});
+            verify(certificationQueryRepository, never()).getDefaultSubCategoryId(anyLong());
+            verify(certificationQueryRepository, never()).findAllCertificationByCategory(categoryId, pageable);
+        }
+
+        @Test
+        void fail_notFoundSubCategoryException(){
+            // given
+            long categoryId = 1L;
+            Pageable pageable = PageableFixture.pageable();
+            Category category = CertificationCategoryFixture.parentCategory();
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+            when(certificationQueryRepository.getDefaultSubCategoryId(categoryId)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThrows(SubCategoryNotFoundException.class, () -> {certificationService.getAllCertificationsByCategory(categoryId, pageable);});
+            verify(certificationQueryRepository, times(1)).getDefaultSubCategoryId(anyLong());
+            verify(certificationQueryRepository, never()).findAllCertificationByCategory(categoryId, pageable);
         }
     }
 

--- a/src/test/java/quartet/server/utils/fixture/Certification/CertificationCategoryFixture.java
+++ b/src/test/java/quartet/server/utils/fixture/Certification/CertificationCategoryFixture.java
@@ -1,11 +1,17 @@
-package quartet.server.utils.fixture;
+package quartet.server.utils.fixture.Certification;
 
 import quartet.server.api.certification.dto.response.CertificationCategoriesRes;
 import quartet.server.domain.category.model.Category;
 import java.util.List;
 
 public class CertificationCategoryFixture {
+    public static Category parentCategory(){
+        return Category.of("IT", null);
+    }
 
+    public static Category subCategory(){
+        return Category.of("데이터분석",parentCategory());
+    }
     public static List<CertificationCategoriesRes> categoryResList(){
         return List.of(
                 new CertificationCategoriesRes(1L,"정보통신"),

--- a/src/test/java/quartet/server/utils/fixture/Certification/CertificationFixture.java
+++ b/src/test/java/quartet/server/utils/fixture/Certification/CertificationFixture.java
@@ -1,4 +1,4 @@
-package quartet.server.utils.fixture;
+package quartet.server.utils.fixture.Certification;
 
 import quartet.server.api.certification.dto.response.CertificationRes;
 import quartet.server.api.certification.dto.response.CertificationsByCategoryRes;

--- a/src/test/java/quartet/server/utils/fixture/Pageable/PageableFixture.java
+++ b/src/test/java/quartet/server/utils/fixture/Pageable/PageableFixture.java
@@ -1,0 +1,14 @@
+package quartet.server.utils.fixture.Pageable;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+
+public class PageableFixture {
+    public static Pageable pageable(){
+        return PageRequest.of(0, 10);
+    }
+    public static Pageable pageable(int page, int pageSize) {
+        return PageRequest.of(page, pageSize);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,18 +1,13 @@
 spring:
-  profiles:
-    active: test
   datasource:
-    url: ""
-    username: ""
-    password: ""
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
   jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: none
-    show-sql: false
-  sql:
-    init:
-      mode: never
-
-logging:
-  level:
-    root: INFO
+      ddl-auto: update


### PR DESCRIPTION
## ✨관련 이슈
#44 

## 📍 주요 변경 사항
- 자격증 조회 실패 예외 추가
- 카테고리별 자격증 조회 로직 변경
   1) 클라이언트에서 categoryId에 대분류 or 소분류 카테고리 id를 보내면, 서버에서 대분류/소분류 판단을 합니다
      (isSubCategory 요청변수 삭제 - 카테고리 종류 판단을 요청 변수가 아닌 서버에서 담당하도록 변경)
   2) 카테고리 조회 실패시, 예외 처리는 비즈니스 로직 담당인 서비스 계층에서 하도록 수정하였습니다(repository -> service)
   3) 대분류 카테고리 조회 실패 및 소분류 카테고리 조회 실패 예외를 분리하였습니다.(에러 원인 구분 가능하도록)

- 위의 수정사항에 대한 테스트 코드 추가
- 테스트 코드에서 공통적으로 사용할 수 있는 Pageable 픽스쳐 생성


## 📝 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성
- [x] 변경 사항에 대한 테스트 코드를 작성
- [ ] 코드 리뷰를 진행

## 기타
- 테스트 코드 작성시, Pageable mock 객체가 필요한 경우 fixture를 사용할 수 있습니다.