### PR TITLE
AWS S3를 이용한 이미지 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,10 @@ dependencies {
 
 	// swagger TODO 박현제: 임시. 나중에 삭제 예정
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+
+	// S3 bucket
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.472'
 }
 
 tasks.named('test') {

--- a/src/main/java/quartet/server/core/advice/GlobalExceptionHandler.java
+++ b/src/main/java/quartet/server/core/advice/GlobalExceptionHandler.java
@@ -10,12 +10,14 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import quartet.server.api.common.response.ApiResponse;
 import quartet.server.core.code.CommonErrorCode;
 import quartet.server.core.exception.BaseException;
 import quartet.server.domain.calender.exception.CalendarException;
 import quartet.server.domain.example.exception.ExampleException;
+import quartet.server.domain.image.exception.ImageException;
 import quartet.server.domain.mail.exception.MailException;
 
 @RestControllerAdvice
@@ -64,6 +66,12 @@ public class GlobalExceptionHandler {
         return ApiResponse.fail(CommonErrorCode.URL_NOT_FOUND);
     }
 
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    protected ApiResponse<Void> handleMaxUploadSizeExceededException(final MaxUploadSizeExceededException e) {
+        log.warn("[MaxUploadSizeExceededException]", e);
+        return ApiResponse.fail(CommonErrorCode.FILE_SIZE_EXCEEDED);
+    }
+
     @ExceptionHandler(ExampleException.class)
     protected ApiResponse<Void> handleExampleException(final ExampleException e) {
         log.warn("[ExampleException] : {}", e.getMessage(), e);
@@ -78,6 +86,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MailException.class)
     protected ApiResponse<Void> handleMailException(final MailException e) {
         log.warn("[MailException] : {}", e.getMessage(), e);
+        return ApiResponse.fail(e.getErrorCode());
+    }
+
+    @ExceptionHandler(ImageException.class)
+    protected ApiResponse<Void> handleImageException(final ImageException e) {
+        log.warn("[ImageException] : {}", e.getMessage(), e);
         return ApiResponse.fail(e.getErrorCode());
     }
 

--- a/src/main/java/quartet/server/core/code/CommonErrorCode.java
+++ b/src/main/java/quartet/server/core/code/CommonErrorCode.java
@@ -10,7 +10,8 @@ public enum CommonErrorCode implements ResponseCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력 값입니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
-    URL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 URL입니다.");
+    URL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 URL입니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "파일 크기가 너무 큽니다. 최대 10MB까지 업로드 가능합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/quartet/server/core/code/ImageErrorCode.java
+++ b/src/main/java/quartet/server/core/code/ImageErrorCode.java
@@ -1,0 +1,17 @@
+package quartet.server.core.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageErrorCode implements ResponseCode {
+    INVALID_IMAGE_URL_FORMAT(HttpStatus.BAD_REQUEST, "잘못된 이미지 URL 형식입니다."),
+    IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다."),
+    IMAGE_DELETION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 삭제에 실패했습니다."),
+    UNSUPPORTED_IMAGE_FORMAT(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 이미지 형식입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/quartet/server/core/config/S3Config.java
+++ b/src/main/java/quartet/server/core/config/S3Config.java
@@ -1,0 +1,32 @@
+package quartet.server.core.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/quartet/server/core/config/S3Config.java
+++ b/src/main/java/quartet/server/core/config/S3Config.java
@@ -1,5 +1,6 @@
 package quartet.server.core.config;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
@@ -23,10 +24,16 @@ public class S3Config {
     @Bean
     public AmazonS3 amazonS3Client() {
         BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        ClientConfiguration clientConfiguration = new ClientConfiguration();
+        clientConfiguration.setConnectionTimeout(5000);
+        clientConfiguration.setSocketTimeout(20000);
+
         return AmazonS3ClientBuilder
                 .standard()
                 .withRegion(region)
                 .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withClientConfiguration(clientConfiguration)
                 .build();
     }
 }

--- a/src/main/java/quartet/server/core/health/S3HealthIndicator.java
+++ b/src/main/java/quartet/server/core/health/S3HealthIndicator.java
@@ -1,0 +1,61 @@
+package quartet.server.core.health;
+
+import com.amazonaws.services.s3.AmazonS3;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class S3HealthIndicator implements HealthIndicator {
+
+    private final AmazonS3 amazonS3;
+    
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+    
+    @PostConstruct
+    public void validateOnStartup() {
+        Health health = health();
+        if (health.getStatus() != Status.UP) {
+            log.warn("S3 버킷 상태 확인 실패: {}", health.getDetails());
+        } else {
+            log.info("S3 버킷 [{}] 접근 확인 완료", bucketName);
+        }
+    }
+
+    @Override
+    public Health health() {
+        try {
+            long startTime = System.currentTimeMillis();
+            boolean bucketExists = amazonS3.doesBucketExistV2(bucketName);
+            long responseTime = System.currentTimeMillis() - startTime;
+            
+            if (bucketExists) {
+                return Health.up()
+                        .withDetail("bucketName", bucketName)
+                        .withDetail("status", "accessible")
+                        .withDetail("responseTime", responseTime + "ms")
+                        .build();
+            } else {
+                return Health.down()
+                        .withDetail("bucketName", bucketName)
+                        .withDetail("reason", "Bucket does not exist")
+                        .withDetail("responseTime", responseTime + "ms")
+                        .build();
+            }
+        } catch (Exception e) {
+            return Health.down()
+                    .withDetail("bucketName", bucketName)
+                    .withDetail("error", e.getClass().getName())
+                    .withDetail("message", e.getMessage())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/quartet/server/domain/image/exception/ImageDeletionFailedException.java
+++ b/src/main/java/quartet/server/domain/image/exception/ImageDeletionFailedException.java
@@ -1,0 +1,9 @@
+package quartet.server.domain.image.exception;
+
+import quartet.server.core.code.ImageErrorCode;
+
+public class ImageDeletionFailedException extends ImageException {
+    public ImageDeletionFailedException() {
+        super(ImageErrorCode.IMAGE_DELETION_FAILED);
+    }
+}

--- a/src/main/java/quartet/server/domain/image/exception/ImageException.java
+++ b/src/main/java/quartet/server/domain/image/exception/ImageException.java
@@ -1,0 +1,10 @@
+package quartet.server.domain.image.exception;
+
+import quartet.server.core.code.ResponseCode;
+import quartet.server.core.exception.BaseException;
+
+public class ImageException extends BaseException {
+    public ImageException(final ResponseCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/quartet/server/domain/image/exception/ImageUploadFailedException.java
+++ b/src/main/java/quartet/server/domain/image/exception/ImageUploadFailedException.java
@@ -1,0 +1,9 @@
+package quartet.server.domain.image.exception;
+
+import quartet.server.core.code.ImageErrorCode;
+
+public class ImageUploadFailedException extends ImageException {
+    public ImageUploadFailedException() {
+        super(ImageErrorCode.IMAGE_UPLOAD_FAILED);
+    }
+}

--- a/src/main/java/quartet/server/domain/image/exception/InvalidImageUrlFormatException.java
+++ b/src/main/java/quartet/server/domain/image/exception/InvalidImageUrlFormatException.java
@@ -1,0 +1,9 @@
+package quartet.server.domain.image.exception;
+
+import quartet.server.core.code.ImageErrorCode;
+
+public class InvalidImageUrlFormatException extends ImageException {
+    public InvalidImageUrlFormatException() {
+        super(ImageErrorCode.INVALID_IMAGE_URL_FORMAT);
+    }
+}

--- a/src/main/java/quartet/server/domain/image/service/ImageService.java
+++ b/src/main/java/quartet/server/domain/image/service/ImageService.java
@@ -1,0 +1,99 @@
+package quartet.server.domain.image.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import quartet.server.domain.image.exception.ImageDeletionFailedException;
+import quartet.server.domain.image.exception.ImageUploadFailedException;
+import quartet.server.domain.image.exception.InvalidImageUrlFormatException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ImageService {
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    private final String IMAGE_FOLDER = "images/";
+
+    public String uploadImage(MultipartFile file) {
+        try {
+            String fileName = IMAGE_FOLDER + UUID.randomUUID() + "_" + file.getOriginalFilename();
+
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType(file.getContentType());
+            metadata.setContentLength(file.getSize());
+
+            amazonS3.putObject(new PutObjectRequest(
+                    bucketName, fileName, file.getInputStream(), metadata));
+
+            return amazonS3.getUrl(bucketName, fileName).toString();
+        } catch (IOException e) {
+            log.error("[IOException] : 파일 입출력 오류 - {}", e.getMessage(), e);
+            throw new ImageUploadFailedException();
+        } catch (AmazonS3Exception e) {
+            log.error("[AmazonS3Exception] : S3 서비스 오류 - {}", e.getMessage(), e);
+            throw new ImageUploadFailedException();
+        } catch (Exception e) {
+            log.error("[Exception] : 이미지 업로드 중 예상치 못한 오류 - {}", e.getMessage(), e);
+            throw new ImageUploadFailedException();
+        }
+    }
+
+    public String updateImage(String oldImageUrl, MultipartFile newFile) {
+        String newImageUrl = uploadImage(newFile);
+
+        if (oldImageUrl != null && !oldImageUrl.isEmpty()) {
+            deleteImage(oldImageUrl);
+        }
+
+        return newImageUrl;
+    }
+
+    public void deleteImage(String oldImageUrl) {
+        try {
+            amazonS3.deleteObject(new DeleteObjectRequest(bucketName, extractFileNameFromUrl(oldImageUrl)));
+        }
+        catch (AmazonS3Exception e) {
+            log.error("[AmazonS3Exception] : S3 서비스 오류 - {}", e.getMessage(), e);
+            throw new ImageDeletionFailedException();
+        } catch (Exception e) {
+            log.error("[Exception] : 이미지 삭제 중 예상치 못한 오류 - {}", e.getMessage(), e);
+            throw new ImageDeletionFailedException();
+        }
+    }
+
+    private String extractFileNameFromUrl(String imageUrl) {
+        try {
+            URI uri = new URI(imageUrl);
+            String path = uri.getPath();
+
+            if (uri.getScheme() == null || uri.getHost() == null || uri.getPath() == null) {
+                throw new InvalidImageUrlFormatException();
+            }
+
+            if (path.startsWith("/")) {
+                path = path.substring(1);
+            }else{
+                throw new InvalidImageUrlFormatException();
+            }
+
+            return path;
+        } catch (Exception e) {
+            throw new InvalidImageUrlFormatException();
+        }
+    }
+}

--- a/src/main/resources/application-develop.yml
+++ b/src/main/resources/application-develop.yml
@@ -40,6 +40,11 @@ spring:
     resources:
       add-mappings: false
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
 management:
   endpoints:
     web:
@@ -59,3 +64,15 @@ security:
 externals:
   public-data:
     service-key: ""
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_S3_ACCESS_KEY}
+      secret-key: ${AWS_S3_SECRET_KEY}
+    region:
+      static: ${AWS_REGION}
+    stack:
+      auto: false
+    s3:
+      bucket: ${AWS_S3_BUCKET}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -35,6 +35,11 @@ spring:
     resources:
       add-mappings: false
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
 management:
   endpoints:
     web:
@@ -46,3 +51,15 @@ management:
 
 server:
   port: 8080
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_S3_ACCESS_KEY}
+      secret-key: ${AWS_S3_SECRET_KEY}
+    region:
+      static: ${AWS_REGION}
+    stack:
+      auto: false
+    s3:
+      bucket: ${AWS_S3_BUCKET}

--- a/src/test/java/quartet/server/api/image/fixture/ImageFixture.java
+++ b/src/test/java/quartet/server/api/image/fixture/ImageFixture.java
@@ -1,0 +1,35 @@
+package quartet.server.api.image.fixture;
+
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URL;
+
+public class ImageFixture {
+
+    private static final String TEST_IMAGE_NAME = "test-image.jpg";
+    private static final String TEST_IMAGE_CONTENT_TYPE = "image/jpeg";
+    private static final byte[] TEST_IMAGE_CONTENT = "test image content".getBytes();
+    private static final String TEST_IMAGE_URL = "https://test-bucket.s3.amazonaws.com/images/uuid_test-image.jpg";
+    private static final String TEST_NEW_IMAGE_URL = "https://test-bucket.s3.amazonaws.com/images/new_uuid_test-image.jpg";
+
+    public static MultipartFile createMockMultipartFile() {
+        return new MockMultipartFile(
+                "file",
+                TEST_IMAGE_NAME,
+                TEST_IMAGE_CONTENT_TYPE,
+                TEST_IMAGE_CONTENT
+        );
+    }
+
+    public static URL createMockUrl() throws Exception {
+        return new URL(TEST_IMAGE_URL);
+    }
+    public static URL createMockNewUrl() throws Exception {
+        return new URL(TEST_NEW_IMAGE_URL);
+    }
+
+    public static String getTestImageUrl() {
+        return TEST_IMAGE_URL;
+    }
+}

--- a/src/test/java/quartet/server/api/image/service/ImageServiceTest.java
+++ b/src/test/java/quartet/server/api/image/service/ImageServiceTest.java
@@ -1,0 +1,331 @@
+package quartet.server.api.image.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+import quartet.server.api.image.fixture.ImageFixture;
+import quartet.server.domain.image.exception.ImageDeletionFailedException;
+import quartet.server.domain.image.exception.ImageUploadFailedException;
+import quartet.server.domain.image.exception.InvalidImageUrlFormatException;
+import quartet.server.domain.image.service.ImageService;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ImageServiceTest {
+
+    @Mock
+    private AmazonS3 amazonS3;
+
+    @InjectMocks
+    private ImageService imageService;
+
+    private final String BUCKET_NAME = "test-bucket";
+
+    @Nested
+    @DisplayName("이미지 업로드")
+    class UploadImageTest {
+
+        @Test
+        @DisplayName("이미지를 성공적으로 업로드한다")
+        void success_uploadImage_shouldReturnImageUrl() throws Exception {
+            // given
+            ReflectionTestUtils.setField(imageService, "bucketName", BUCKET_NAME);
+            final MultipartFile mockFile = ImageFixture.createMockMultipartFile();
+            final URL mockUrl = ImageFixture.createMockUrl();
+
+            when(amazonS3.putObject(any(PutObjectRequest.class))).thenReturn(null);
+            when(amazonS3.getUrl(eq(BUCKET_NAME), any(String.class))).thenReturn(mockUrl);
+
+            // when
+            final String result = imageService.uploadImage(mockFile);
+
+            // then
+            assertThat(result).isEqualTo(mockUrl.toString());
+            verify(amazonS3, times(1)).putObject(any(PutObjectRequest.class));
+            verify(amazonS3, times(1)).getUrl(eq(BUCKET_NAME), any(String.class));
+        }
+
+        @Test
+        @DisplayName("파일 입출력 오류로 이미지 업로드에 실패한다")
+        void fail_uploadImage_whenIOExceptionOccurs() throws Exception {
+            // given
+            ReflectionTestUtils.setField(imageService, "bucketName", BUCKET_NAME);
+            final MultipartFile mockFile = mock(MultipartFile.class);
+
+            when(mockFile.getOriginalFilename()).thenReturn("test-image.jpg");
+            when(mockFile.getContentType()).thenReturn("image/jpeg");
+            when(mockFile.getSize()).thenReturn(1024L);
+            when(mockFile.getInputStream()).thenThrow(new IOException("파일 입출력 오류"));
+
+            // when & then
+            assertThatThrownBy(() -> imageService.uploadImage(mockFile))
+                    .isInstanceOf(ImageUploadFailedException.class);
+
+            verify(amazonS3, never()).putObject(any(PutObjectRequest.class));
+        }
+
+        @Test
+        @DisplayName("S3 서비스 오류로 이미지 업로드에 실패한다")
+        void fail_uploadImage_whenAmazonS3ExceptionOccurs() throws Exception {
+            // given
+            ReflectionTestUtils.setField(imageService, "bucketName", BUCKET_NAME);
+            final MultipartFile mockFile = ImageFixture.createMockMultipartFile();
+
+            when(amazonS3.putObject(any(PutObjectRequest.class)))
+                    .thenThrow(new AmazonS3Exception("S3 서비스 오류"));
+
+            // when & then
+            assertThatThrownBy(() -> imageService.uploadImage(mockFile))
+                    .isInstanceOf(ImageUploadFailedException.class);
+
+            verify(amazonS3, times(1)).putObject(any(PutObjectRequest.class));
+        }
+    }
+    @Nested
+    @DisplayName("이미지 업데이트")
+    class UpdateImageTest {
+
+        @Test
+        @DisplayName("이미지를 성공적으로 업데이트한다")
+        void success_updateImage_shouldReturnNewImageUrl() throws Exception {
+            // given
+            ReflectionTestUtils.setField(imageService, "bucketName", BUCKET_NAME);
+            final String oldImageUrl = ImageFixture.getTestImageUrl();
+            final MultipartFile newFile = ImageFixture.createMockMultipartFile();
+            final URL mockNewUrl =ImageFixture.createMockNewUrl();
+
+            ImageService spyImageService = spy(imageService);
+            doReturn(mockNewUrl.toString()).when(spyImageService).uploadImage(any(MultipartFile.class));
+
+            doNothing().when(spyImageService).deleteImage(anyString());
+
+            // when
+            final String result = spyImageService.updateImage(oldImageUrl, newFile);
+
+            // then
+            assertThat(result).isEqualTo(mockNewUrl.toString());
+            verify(spyImageService, times(1)).uploadImage(any(MultipartFile.class));
+            verify(spyImageService, times(1)).deleteImage(oldImageUrl);
+        }
+
+        @Test
+        @DisplayName("이전 이미지 URL이 null일 때 성공적으로 새 이미지를 업로드한다")
+        void success_updateImage_whenOldImageUrlIsNull() throws Exception {
+            // given
+            ReflectionTestUtils.setField(imageService, "bucketName", BUCKET_NAME);
+            final String oldImageUrl = null;
+            final MultipartFile newFile = ImageFixture.createMockMultipartFile();
+            final URL mockNewUrl = ImageFixture.createMockNewUrl();
+
+            ImageService spyImageService = spy(imageService);
+            doReturn(mockNewUrl.toString()).when(spyImageService).uploadImage(any(MultipartFile.class));
+
+            // when
+            final String result = spyImageService.updateImage(oldImageUrl, newFile);
+
+            // then
+            assertThat(result).isEqualTo(mockNewUrl.toString());
+            verify(spyImageService, times(1)).uploadImage(any(MultipartFile.class));
+            verify(spyImageService, never()).deleteImage(anyString());
+        }
+
+        @Test
+        @DisplayName("이전 이미지 URL이 빈 문자열일 때 성공적으로 새 이미지를 업로드한다")
+        void success_updateImage_whenOldImageUrlIsEmpty() throws Exception {
+            // given
+            ReflectionTestUtils.setField(imageService, "bucketName", BUCKET_NAME);
+            final String oldImageUrl = "";
+            final MultipartFile newFile = ImageFixture.createMockMultipartFile();
+            final URL mockNewUrl = ImageFixture.createMockNewUrl();
+
+            ImageService spyImageService = spy(imageService);
+            doReturn(mockNewUrl.toString()).when(spyImageService).uploadImage(any(MultipartFile.class));
+
+            // when
+            final String result = spyImageService.updateImage(oldImageUrl, newFile);
+
+            // then
+            assertThat(result).isEqualTo(mockNewUrl.toString());
+            verify(spyImageService, times(1)).uploadImage(any(MultipartFile.class));
+            verify(spyImageService, never()).deleteImage(anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("이미지 삭제")
+    class DeleteImageTest {
+
+        @Test
+        @DisplayName("이미지를 성공적으로 삭제한다")
+        void success_deleteImage() {
+            // given
+            ReflectionTestUtils.setField(imageService, "bucketName", BUCKET_NAME);
+            final String imageUrl = ImageFixture.getTestImageUrl();
+
+            doNothing().when(amazonS3).deleteObject(any(DeleteObjectRequest.class));
+
+            // when
+            imageService.deleteImage(imageUrl);
+
+            // then
+            verify(amazonS3, times(1)).deleteObject(any(DeleteObjectRequest.class));
+        }
+
+        @Test
+        @DisplayName("S3 서비스 오류로 이미지 삭제에 실패한다")
+        void fail_deleteImage_whenAmazonS3ExceptionOccurs() {
+            // given
+            ReflectionTestUtils.setField(imageService, "bucketName", BUCKET_NAME);
+            final String imageUrl = ImageFixture.getTestImageUrl();
+
+            doThrow(new AmazonS3Exception("S3 서비스 오류"))
+                    .when(amazonS3).deleteObject(any(DeleteObjectRequest.class));
+
+            // when & then
+            assertThatThrownBy(() -> imageService.deleteImage(imageUrl))
+                    .isInstanceOf(ImageDeletionFailedException.class);
+
+            verify(amazonS3, times(1)).deleteObject(any(DeleteObjectRequest.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("URL에서 파일명 추출")
+    class ExtractFileNameFromUrlTest {
+
+        @Test
+        @DisplayName("URL에서 파일명을 성공적으로 추출한다")
+        void success_extractFileNameFromUrl() {
+            // given
+            final String imageUrl = ImageFixture.getTestImageUrl();
+            final String expectedFileName = "images/uuid_test-image.jpg";
+
+            // when
+            final String result = ReflectionTestUtils.invokeMethod(
+                    imageService,
+                    "extractFileNameFromUrl",
+                    imageUrl
+            );
+
+            // then
+            assertThat(result).isEqualTo(expectedFileName);
+        }
+
+        @Test
+        @DisplayName("유효한 S3 URL에서 파일명을 성공적으로 추출한다")
+        void success_extractFileNameFromUrl_withValidUrl() {
+            // given
+            final String validUrl = "https://test-bucket.s3.amazonaws.com/images/uuid_test-image.jpg";
+            final String expectedPath = "images/uuid_test-image.jpg";
+
+            // when
+            final String result = ReflectionTestUtils.invokeMethod(
+                    imageService,
+                    "extractFileNameFromUrl",
+                    validUrl
+            );
+
+            // then
+            assertThat(result).isEqualTo(expectedPath);
+        }
+
+        @Test
+        @DisplayName("잘못된 URL 형식으로 파일명 추출에 실패한다 - 스키마 없음")
+        void fail_extractFileNameFromUrl_whenNoScheme() {
+            // given
+            final String invalidUrl = "test-bucket.s3.amazonaws.com/images/test.jpg";
+
+            // when & then
+            assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(
+                    imageService,
+                    "extractFileNameFromUrl",
+                    invalidUrl
+            )).isInstanceOf(InvalidImageUrlFormatException.class);
+        }
+
+        @Test
+        @DisplayName("잘못된 URL 형식으로 파일명 추출에 실패한다 - 호스트 없음")
+        void fail_extractFileNameFromUrl_whenNoHost() {
+            // given
+            final String invalidUrl = "https:///images/test.jpg";
+
+            // when & then
+            assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(
+                    imageService,
+                    "extractFileNameFromUrl",
+                    invalidUrl
+            )).isInstanceOf(InvalidImageUrlFormatException.class);
+        }
+
+        @Test
+        @DisplayName("잘못된 URL 형식으로 파일명 추출에 실패한다 - 경로 없음")
+        void fail_extractFileNameFromUrl_whenNoPath() {
+            // given
+            final String invalidUrl = "https://test-bucket.s3.amazonaws.com";
+
+            // when & then
+            assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(
+                    imageService,
+                    "extractFileNameFromUrl",
+                    invalidUrl
+            )).isInstanceOf(InvalidImageUrlFormatException.class);
+        }
+
+        @Test
+        @DisplayName("잘못된 URL 형식으로 파일명 추출에 실패한다 - 구문 오류")
+        void fail_extractFileNameFromUrl_whenSyntaxError() {
+            // given
+            final String invalidUrl = "http://exa mple.com/test.jpg";
+
+            // when & then
+            assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(
+                    imageService,
+                    "extractFileNameFromUrl",
+                    invalidUrl
+            )).isInstanceOf(InvalidImageUrlFormatException.class);
+        }
+
+        @Test
+        @DisplayName("null URL로 파일명 추출에 실패한다")
+        void fail_extractFileNameFromUrl_whenUrlIsNull() {
+            // when & then
+            assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(
+                    imageService,
+                    "extractFileNameFromUrl",
+                    (String) null
+            )).isInstanceOf(InvalidImageUrlFormatException.class);
+        }
+
+        @Test
+        @DisplayName("빈 문자열 URL로 파일명 추출에 실패한다")
+        void fail_extractFileNameFromUrl_whenUrlIsEmpty() {
+            // given
+            final String emptyUrl = "";
+
+            // when & then
+            assertThatThrownBy(() -> ReflectionTestUtils.invokeMethod(
+                    imageService,
+                    "extractFileNameFromUrl",
+                    emptyUrl
+            )).isInstanceOf(InvalidImageUrlFormatException.class);
+        }
+    }
+}


### PR DESCRIPTION
## ✨관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#70 
## 📍 주요 변경 사항
<!-- 변화한 내용을 적어주세요. 어떻게 수정했는지 설명해주세요. -->
### 1.  이미지 업로드, 수정, 삭제 로직 추가
이미지 업로드, 수정, 삭제할 때```ImageService```를 이용하시면 됩니다.
#### 업로드
- ```imageService.uploadImage(이미지 파일)``` -> 반환값: image url
#### 수정
- ```imageService.updateImage(수정할 image url, 수정할 파일)``` -> 반환값: 수정 파일에 대한 image url
#### 삭제
- ```imageService.deleteImage(삭제할 image url)```


> 참고) 이미지 업로드 구현을 위해 클라이언트로부터 받는 RequestDto에 MultipartFile를 컬럼이 포함되어 있다면, Controller 메서드의 매개변수에서 ```@ModelAttribute RequestDto dto```와 같은 형식을 사용해서 받아주시면 됩니다.
**추가로 프론트에서는 Content-Type을 multipart/form-data로 지정해서 보내도록 API 문서에 명시해주세요!**

> 예시)
> ``` java
> @RestController
> public class ImageController {
> ...
>     @PostMapping("/upload")
>     public ApiResponse<Void> uploadImage(@ModelAttribute ImageUploadRequest request) {
>         String imageUrl = imageService.uploadImage(request.getImageFile());
>         return ApiResponse.success(CREATED);
>     }
> }
> @Getter
> @Setter
> @NoArgsConstructor
> public class ImageUploadRequest {
>     // 다른 필드들 (예: 제목, 설명 등)
>    private String title;
>    private String description;
>   
>    // MultipartFile 필드
>    private MultipartFile imageFile;
> }
> ```


### 2. S3HealthIndicator 추가
S3 버킷이 연결 가능한지 체크합니다.

### 3. S3 버킷 Timeout 추가
- 큰 데이터를 저장할 일은 없을듯해서 1회 파일 업로드 용량을 최대 10mb로 설정했습니다.
- 용량이 크지 않기 때문에 자원낭비를 줄이기 위해 연결 timeout 5초, 소켓 timeout 20초로 설정했습니다.

## 📝 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성
- [x] 변경 사항에 대한 테스트 코드를 작성
- [x] 코드 리뷰를 진행