### PR TITLE
이메일 전송 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,12 @@ dependencies {
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 
+	// mail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	// thymeleaf
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
 	// swagger TODO 박현제: 임시. 나중에 삭제 예정
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 
@@ -57,6 +63,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'io.jsonwebtoken:jjwt:0.12.3'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+	// AOP
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/src/main/java/quartet/server/api/calendar/controller/CalendarController.java
+++ b/src/main/java/quartet/server/api/calendar/controller/CalendarController.java
@@ -36,9 +36,4 @@ public class CalendarController {
         calendarService.unsubscribeCalendar(certificationId, memberId);
         return ApiResponse.success(NO_CONTENT);
     }
-//    @GetMapping("/certifications/by-date")
-//    public ResponseEntity<List<CalendarResponse>> getCalendarsByDate() {
-//        List<CalendarResponse> responses = calendarService.getCalendarDataByMemberIdAndDateRange(1L);
-//        return ResponseEntity.ok(responses);
-//    }
 }

--- a/src/main/java/quartet/server/api/calendar/dto/response/CalendarResponse.java
+++ b/src/main/java/quartet/server/api/calendar/dto/response/CalendarResponse.java
@@ -64,7 +64,7 @@ public record CalendarResponse(
 
         public static CalendarScheduleResponse of(
                 String scheduleType,
-                String examType,
+                ExamType examType,
                 String examRound,
                 List<Instant> date
         ) {

--- a/src/main/java/quartet/server/api/calendar/service/CalendarService.java
+++ b/src/main/java/quartet/server/api/calendar/service/CalendarService.java
@@ -47,14 +47,8 @@ public class CalendarService {
         }
 
         final Instant dbStartDate = DateUtils.getDateBefore(DateUtils.toLocalDate(startDate),0, 1, 0);
-
-
         final Instant dbEndDate = DateUtils.getDateAfter(DateUtils.toLocalDate(endDate),0, 1, 0);
-        System.out.println("========================");
-        System.out.println("startDate = " + startDate);
-        System.out.println("endDate = " + endDate);
-        System.out.println("dbStartDate = " + dbStartDate);
-        System.out.println("dbEndDate = " + dbEndDate);
+
         final Map<Long, Map<ScheduleKey, List<Instant>>> groupedSchedulesByCertificationId =
                 calendarQueryRepository.findCalendarSchedulesByCertificationIdsAndDateRange(certificationIds, dbStartDate, dbEndDate);
 
@@ -128,7 +122,7 @@ public class CalendarService {
 
         return CalendarResponse.CalendarScheduleResponse.of(
                 entry.getKey().scheduleType(),
-                entry.getKey().examType().getValue(),
+                entry.getKey().examType(),
                 entry.getKey().examRound(),
                 filteredDates
         );

--- a/src/main/java/quartet/server/api/mail/controller/EmailTestController.java
+++ b/src/main/java/quartet/server/api/mail/controller/EmailTestController.java
@@ -1,0 +1,27 @@
+package quartet.server.api.mail.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import quartet.server.api.common.response.ApiResponse;
+import quartet.server.api.mail.service.MailingScheduleService;
+
+import static quartet.server.core.code.CommonSuccessCode.NO_CONTENT;
+
+@RestController
+@RequestMapping("/api/v1/mailings")
+@RequiredArgsConstructor
+public class EmailTestController { // todo: 테스트 후 삭제 예정
+
+    private final MailingScheduleService mailingScheduleService;
+
+    /**
+     * 이메일 전송 직접 테스트
+     */
+    @PostMapping("/schedule")
+    public ApiResponse<Void> sendWelcomeEmail() {
+        mailingScheduleService.sendDailyNotifications();
+        return ApiResponse.success(NO_CONTENT);
+    }
+}

--- a/src/main/java/quartet/server/api/mail/dto/response/ApplicationMailProjection.java
+++ b/src/main/java/quartet/server/api/mail/dto/response/ApplicationMailProjection.java
@@ -1,0 +1,38 @@
+package quartet.server.api.mail.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import quartet.server.domain.certification.type.ExamType;
+
+import java.time.Instant;
+
+public record ApplicationMailProjection(
+        Long memberId,
+        Long certificationId,
+        String userName,
+        String email,
+        String certificationName,
+        Instant applicationDate,
+        String applicationUrl,
+        ExamType examType
+) {
+    @QueryProjection
+    public ApplicationMailProjection(
+            Long memberId,
+            Long certificationId,
+            String userName,
+            String email,
+            String certificationName,
+            Instant applicationDate,
+            String applicationUrl,
+            ExamType examType
+    ) {
+        this.memberId = memberId;
+        this.certificationId = certificationId;
+        this.userName = userName;
+        this.email = email;
+        this.certificationName = certificationName;
+        this.applicationDate = applicationDate;
+        this.applicationUrl = applicationUrl;
+        this.examType = examType;
+    }
+}

--- a/src/main/java/quartet/server/api/mail/dto/response/ApplicationMailResponse.java
+++ b/src/main/java/quartet/server/api/mail/dto/response/ApplicationMailResponse.java
@@ -1,0 +1,67 @@
+package quartet.server.api.mail.dto.response;
+
+import quartet.server.domain.certification.type.ExamType;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+public record ApplicationMailResponse(
+        Long memberId,
+        String userName,
+        String email,
+        List<CertificationInfoResponse> certifications
+) {
+    public ApplicationMailResponse(
+            Long memberId,
+            String userName,
+            String email)
+    {
+        this(
+                memberId,
+                userName,
+                email,
+                new ArrayList<>()
+        );
+    }
+
+    public static ApplicationMailResponse of(
+            Long memberId,
+            String userName,
+            String email
+    ) {
+        return new ApplicationMailResponse(
+                memberId,
+                userName,
+                email
+        );
+    }
+
+    public void addCertificationInfo(CertificationInfoResponse response) {
+        certifications.add(response);
+    }
+
+    public record CertificationInfoResponse(
+            Long certificationId,
+            String certificationName,
+            Instant date,
+            String applicationUrl,
+            ExamType examType
+    ) {
+        public static CertificationInfoResponse of(
+                Long certificationId,
+                String certificationName,
+                Instant date,
+                String applicationUrl,
+                ExamType examType
+        ) {
+            return new CertificationInfoResponse(
+                    certificationId,
+                    certificationName,
+                    date,
+                    applicationUrl,
+                    examType
+            );
+        }
+    }
+}

--- a/src/main/java/quartet/server/api/mail/dto/response/ExamMailResponse.java
+++ b/src/main/java/quartet/server/api/mail/dto/response/ExamMailResponse.java
@@ -1,0 +1,35 @@
+package quartet.server.api.mail.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import quartet.server.domain.certification.type.ExamType;
+
+import java.time.Instant;
+
+public record ExamMailResponse(
+    Long memberId,
+    Long certificationId,
+    String userName,
+    String email,
+    String certificationName,
+    Instant examDate,
+    ExamType examType
+) {
+    @QueryProjection
+    public ExamMailResponse(
+        Long memberId,
+        Long certificationId,
+        String userName,
+        String email,
+        String certificationName,
+        Instant examDate,
+        ExamType examType
+    ) {
+        this.memberId = memberId;
+        this.certificationId = certificationId;
+        this.userName = userName;
+        this.email = email;
+        this.certificationName = certificationName;
+        this.examDate = examDate;
+        this.examType = examType;
+    }
+}

--- a/src/main/java/quartet/server/api/mail/query/MailingQueryRepository.java
+++ b/src/main/java/quartet/server/api/mail/query/MailingQueryRepository.java
@@ -8,12 +8,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
-import quartet.server.api.mail.dto.response.MailingResponse;
-import quartet.server.api.mail.dto.response.QMailingResponse;
+import quartet.server.api.mail.dto.response.*;
+import quartet.server.core.utils.DateUtils;
+import quartet.server.domain.certification.model.QAuthority;
 import quartet.server.domain.certification.model.QCertification;
 import quartet.server.domain.certification.model.QCertificationSchedule;
 import quartet.server.domain.certification.type.ScheduleType;
 import quartet.server.domain.mail.model.QMailing;
+import quartet.server.domain.mail.type.MailingStatus;
+import quartet.server.domain.member.model.QMember;
 
 import java.time.Instant;
 import java.util.Collections;
@@ -79,5 +82,76 @@ public class MailingQueryRepository {
                 ));
 
         return new PageImpl<>(content, pageable, total);
+    }
+
+    public List<ApplicationMailProjection> findAllMailingTargetsForDate(
+            Instant targetDate, MailingStatus requiredMailingStatus) {
+
+        QMailing mailing = QMailing.mailing;
+        QMember member = QMember.member;
+        QCertification certification = QCertification.certification;
+        QCertificationSchedule schedule = QCertificationSchedule.certificationSchedule;
+        QAuthority authority = QAuthority.authority;
+
+        Instant startOfDay = DateUtils.getDayStart(targetDate);
+        Instant endOfDay = DateUtils.getDayEnd(targetDate);
+
+        return queryFactory
+                .select(new QApplicationMailProjection(
+                        member.id,
+                        certification.id,
+                        member.nickname,
+                        member.email,
+                        certification.name,
+                        schedule.date,
+                        authority.applicationUrl,
+                        schedule.examType))
+                .from(mailing)
+                .join(mailing.member, member)
+                .join(mailing.certification, certification)
+                .join(certification.authority, authority)
+                .join(certification.schedules, schedule)
+                .where(
+                        member.mailingStatus.eq(requiredMailingStatus)
+                                .and(schedule.scheduleType.eq(ScheduleType.APPLICATION_START))
+//                                // examType이 null이거나 WRITTEN인 경우만 포함
+//                                .and(schedule.examType.isNull().or(schedule.examType.eq(ExamType.WRITTEN))) // todo 박현제: 추후에 미포함 여부 검토
+                                .and(schedule.date.between(startOfDay, endOfDay))
+                )
+                .orderBy(member.id.asc())
+                .fetch();
+        }
+
+    public List<ExamMailResponse> findExamNotificationsForDate(
+            Instant targetDate, MailingStatus requiredMailingStatus) {
+
+        QMailing mailing = QMailing.mailing;
+        QMember member = QMember.member;
+        QCertification certification = QCertification.certification;
+        QCertificationSchedule schedule = QCertificationSchedule.certificationSchedule;
+
+
+        Instant startOfDay = DateUtils.getDayStart(targetDate);
+        Instant endOfDay = DateUtils.getDayEnd(targetDate);
+
+        return queryFactory
+                .select(new QExamMailResponse(
+                        member.id,
+                        certification.id,
+                        member.nickname,
+                        member.email,
+                        certification.name,
+                        schedule.date,
+                        schedule.examType))
+                .from(mailing)
+                .join(mailing.member, member)
+                .join(mailing.certification, certification)
+                .join(certification.schedules, schedule)
+                .where(
+                        member.mailingStatus.eq(requiredMailingStatus)
+                                .and(schedule.scheduleType.eq(ScheduleType.EXAM_START))
+                                .and(schedule.date.between(startOfDay, endOfDay))
+                )
+                .fetch();
     }
 }

--- a/src/main/java/quartet/server/api/mail/service/EmailProcessingService.java
+++ b/src/main/java/quartet/server/api/mail/service/EmailProcessingService.java
@@ -1,0 +1,104 @@
+package quartet.server.api.mail.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import quartet.server.api.mail.dto.response.ExamMailResponse;
+import quartet.server.api.mail.dto.response.ApplicationMailResponse;
+import quartet.server.core.aop.EmailSendingStatistics;
+
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+// AOP 인터셉트가 필요한 메서드를 위한 새로운 서비스
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailProcessingService {
+
+    private final EmailService emailService;
+
+    private final int APPLICATION_NOTIFICATION_DAY_BEFORE = 1;
+    private final int EXAM_NOTIFICATION_DAY_BEFORE = 3;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @EmailSendingStatistics(category = "exam")
+    public boolean processExamNotificationInIsolatedTransaction(final ExamMailResponse response) {
+        try {
+            sendExamReminderEmail(response);
+            return true;
+        } catch (Exception e) {
+            log.error("시험 알림 이메일 발송 실패: memberId={}, certificationId={}",
+                    response.memberId(), response.certificationId(), e);
+            return false;
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @EmailSendingStatistics(category = "application")
+    public boolean processApplicationNotificationInIsolatedTransaction(final ApplicationMailResponse response) {
+        try {
+            sendApplicationReminderEmail(response);
+            return true;
+        } catch (Exception e) {
+            log.error("통합 자격증 접수 알림 이메일 발송 실패: memberId={}",
+                    response.memberId(), e);
+            return false;
+        }
+    }
+
+    private void sendApplicationReminderEmail(final ApplicationMailResponse memberMailing) {
+        // 이메일 제목: 여러 자격증이 있을 경우 표시 방법 변경
+        String subject;
+        final int certificationCount = memberMailing.certifications().size();
+        if (certificationCount > 1) {
+            subject = String.format("[자격저격] %d개 자격증 접수일 알림",
+                    certificationCount, APPLICATION_NOTIFICATION_DAY_BEFORE);
+        } else {
+            subject = String.format("[자격저격] %s 접수일 알림", memberMailing.certifications().getFirst().certificationName(), EXAM_NOTIFICATION_DAY_BEFORE);
+        }
+
+        Map<String, Object> contextData = createApplicationEmailContext(memberMailing);
+
+        emailService.sendTemplateEmail(memberMailing.email(), subject, "receipt-day", contextData);
+    }
+
+    private Map<String, Object> createApplicationEmailContext(ApplicationMailResponse response) {
+        Map<String, Object> contextData = new HashMap<>();
+        contextData.put("userName", response.userName());
+        contextData.put("dDay", String.valueOf(APPLICATION_NOTIFICATION_DAY_BEFORE));
+        contextData.put("certifications", response.certifications().stream()
+                .map(cert -> Map.of(
+                        "certificationName", cert.certificationName() + " " + cert.examType().getValue(),
+                        "applicationDate", cert.date().atZone(ZoneId.systemDefault()).toLocalDate().toString(),
+                        "detailLink", "https://www.quartet.com/certifications/" + cert.certificationId(), //todo 박현제: 최종 결정된 프론트 URL에 따라 수정
+                        "applicationUrl", cert.applicationUrl()
+                ))
+                .collect(Collectors.toList())
+        );
+        return contextData;
+    }
+
+    private void sendExamReminderEmail(final ExamMailResponse response) {
+        final String subject = String.format("[자격저격] %s 시험 %d일 전 알림", response.certificationName(), EXAM_NOTIFICATION_DAY_BEFORE);
+
+        Map<String, Object> contextData = createExamEmailContext(response);
+
+        emailService.sendTemplateEmail(response.email(), subject, "exam-day", contextData);
+    }
+
+    private Map<String, Object> createExamEmailContext(ExamMailResponse notification) {
+        Map<String, Object> contextData = new HashMap<>();
+        contextData.put("userName", notification.userName());
+        contextData.put("examName", notification.certificationName());
+        contextData.put("examDate", notification.examDate().atZone(ZoneId.systemDefault()).toLocalDate().toString());
+        contextData.put("dDay", String.valueOf(EXAM_NOTIFICATION_DAY_BEFORE));
+        contextData.put("detailLink", "https://www.quartet.com/certifications/" + notification.certificationId()); //todo 박현제: 최종 결정된 프론트 URL에 따라 수정
+
+        return contextData;
+    }
+}

--- a/src/main/java/quartet/server/api/mail/service/EmailService.java
+++ b/src/main/java/quartet/server/api/mail/service/EmailService.java
@@ -1,0 +1,50 @@
+package quartet.server.api.mail.service;
+
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import quartet.server.domain.mail.exception.EmailSendingFailedException;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+    private final TemplateEngine templateEngine;
+
+    public void sendTemplateEmail(final String to, final String subject, final String templateName, final Map<String, Object> contextData) {
+        try {
+            // 이메일 메시지 생성
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            // 이메일 기본 정보 설정
+            helper.setTo(to);
+            helper.setSubject(subject);
+            helper.setFrom("oneul.team3@gmail.com", "자격저격");
+
+            // Thymeleaf 컨텍스트 생성 및 데이터 설정
+            Context context = new Context();
+            contextData.forEach(context::setVariable);
+
+            // 템플릿을 처리하여 HTML 내용 생성
+            String htmlContent = templateEngine.process("email/" + templateName, context);
+            helper.setText(htmlContent, true);
+
+            // 이메일 발송
+            mailSender.send(message);
+            log.debug("이메일 발송 성공: to={}, subject={}, template={}", to, subject, templateName);
+        } catch (Exception e) {
+            log.error("이메일 발송 실패: to={}, subject={}, template={}", to, subject, templateName, e);
+            throw new EmailSendingFailedException(e);
+        }
+    }
+}

--- a/src/main/java/quartet/server/api/mail/service/MailingScheduleService.java
+++ b/src/main/java/quartet/server/api/mail/service/MailingScheduleService.java
@@ -1,0 +1,87 @@
+package quartet.server.api.mail.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import quartet.server.api.mail.dto.response.*;
+import quartet.server.api.mail.query.MailingQueryRepository;
+import quartet.server.core.utils.DateUtils;
+import quartet.server.domain.mail.type.MailingStatus;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MailingScheduleService {
+
+    private final MailingQueryRepository mailingQueryRepository;
+    private final EmailProcessingService emailProcessingService;
+
+    private final int APPLICATION_NOTIFICATION_DAY_BEFORE = 1;
+    private final int EXAM_NOTIFICATION_DAY_BEFORE = 3;
+
+    @Scheduled(cron = "0 20 3 * * ?")
+    @Transactional(readOnly = true)
+    public void sendDailyNotifications() {
+        log.info("자격증 접수 알림 이메일 발송 스케줄러 실행");
+
+        sendApplicationMail(DateUtils.today());
+
+        sendExamMail(DateUtils.today());
+
+        log.info("일일 이메일 발송 작업 완료");
+    }
+
+    private void sendExamMail(final LocalDate today) {
+        // 특정 일수 후에 시험이 시작되는 날짜 계산
+        LocalDate examDate = today.plusDays(EXAM_NOTIFICATION_DAY_BEFORE);
+        Instant targetInstant = examDate.atStartOfDay(ZoneId.systemDefault()).toInstant();
+
+        List<ExamMailResponse> examNotifications = mailingQueryRepository.findExamNotificationsForDate(
+                targetInstant, MailingStatus.ACTIVE);
+
+        examNotifications.forEach(emailProcessingService::processExamNotificationInIsolatedTransaction);
+    }
+
+    private void sendApplicationMail(final LocalDate today) {
+        // 특정 일수 후에 접수가 시작되는 날짜 계산
+        Instant targetDate = DateUtils.getDateAfter(today, 0, 0, APPLICATION_NOTIFICATION_DAY_BEFORE);
+
+        List<ApplicationMailProjection> allTargets = mailingQueryRepository.findAllMailingTargetsForDate(
+                targetDate, MailingStatus.ACTIVE);
+
+        Map<Long, ApplicationMailResponse> memberMailings = groupTargetsByMemberId(allTargets);
+
+        memberMailings.values().forEach(emailProcessingService::processApplicationNotificationInIsolatedTransaction);
+    }
+
+    private Map<Long, ApplicationMailResponse> groupTargetsByMemberId(final List<ApplicationMailProjection> targets) {
+        Map<Long, ApplicationMailResponse> result = new HashMap<>();
+        
+        for (ApplicationMailProjection target : targets) {
+            ApplicationMailResponse response = result.computeIfAbsent(
+                target.memberId(), 
+                id -> new ApplicationMailResponse(id, target.userName(), target.email())
+            );
+
+            ApplicationMailResponse.CertificationInfoResponse certInfo =
+                    ApplicationMailResponse.CertificationInfoResponse.of(
+                target.certificationId(),
+                target.certificationName(),
+                target.applicationDate(),
+                target.applicationUrl(),
+                target.examType()
+            );
+
+            response.addCertificationInfo(certInfo);
+        }
+        
+        return result;
+    }
+}

--- a/src/main/java/quartet/server/api/mail/service/MailingScheduleService.java
+++ b/src/main/java/quartet/server/api/mail/service/MailingScheduleService.java
@@ -26,7 +26,7 @@ public class MailingScheduleService {
     private final int APPLICATION_NOTIFICATION_DAY_BEFORE = 1;
     private final int EXAM_NOTIFICATION_DAY_BEFORE = 3;
 
-    @Scheduled(cron = "0 20 3 * * ?")
+    @Scheduled(cron = "0 0 8 * * ?")
     @Transactional(readOnly = true)
     public void sendDailyNotifications() {
         log.info("자격증 접수 알림 이메일 발송 스케줄러 실행");

--- a/src/main/java/quartet/server/api/mail/service/MailingService.java
+++ b/src/main/java/quartet/server/api/mail/service/MailingService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import quartet.server.api.mail.dto.response.MailingResponse;
 import quartet.server.api.mail.query.MailingQueryRepository;
+import quartet.server.core.utils.DateUtils;
 import quartet.server.domain.certification.exception.CertificationNotFoundException;
 import quartet.server.domain.certification.model.Certification;
 import quartet.server.domain.certification.repository.CertificationRepository;
@@ -17,8 +18,6 @@ import quartet.server.domain.member.exception.MemberNotFoundException;
 import quartet.server.domain.member.model.Member;
 import quartet.server.domain.member.repository.MemberRepository;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
 import java.util.List;
 
 @Service
@@ -33,7 +32,7 @@ public class MailingService {
 
     public Page<MailingResponse> getMailingsByMemberId(final long memberId, final Pageable pageable) {
         return mailingQueryRepository.getMailingsByMemberId(memberId,
-                LocalDate.now().atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant(),
+                DateUtils.getTodayStart(),
                 pageable);
     }
 

--- a/src/main/java/quartet/server/core/aop/EmailSendingStatistics.java
+++ b/src/main/java/quartet/server/core/aop/EmailSendingStatistics.java
@@ -1,0 +1,12 @@
+package quartet.server.core.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EmailSendingStatistics {
+    String category();
+}

--- a/src/main/java/quartet/server/core/aop/EmailStatisticsAspect.java
+++ b/src/main/java/quartet/server/core/aop/EmailStatisticsAspect.java
@@ -1,0 +1,73 @@
+package quartet.server.core.aop;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.After;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Aspect
+@Component
+@Slf4j
+public class EmailStatisticsAspect {
+    
+    private final Map<String, AtomicInteger> successCounts = new ConcurrentHashMap<>();
+    private final Map<String, AtomicInteger> failureCounts = new ConcurrentHashMap<>();
+    private final Map<String, AtomicInteger> totalCounts = new ConcurrentHashMap<>();
+    
+    @Around("@annotation(emailStats)")
+    public Object collectEmailStatistics(ProceedingJoinPoint joinPoint, EmailSendingStatistics emailStats) throws Throwable {
+        String category = emailStats.category();
+        
+        successCounts.computeIfAbsent(category, k -> new AtomicInteger(0));
+        failureCounts.computeIfAbsent(category, k -> new AtomicInteger(0));
+        totalCounts.computeIfAbsent(category, k -> new AtomicInteger(0));
+        
+        totalCounts.get(category).incrementAndGet();
+        
+        try {
+            Object result = joinPoint.proceed();
+            
+            if (result instanceof Boolean && (Boolean) result) {
+                successCounts.get(category).incrementAndGet();
+            } else {
+                failureCounts.get(category).incrementAndGet();
+            }
+            
+            return result;
+        } catch (Exception e) {
+            failureCounts.get(category).incrementAndGet();
+            throw e;
+        }
+    }
+    
+    @After("execution(* quartet.server.api.mail.service.MailingScheduleService.sendDailyNotifications())")
+    public void logDailyStatistics() {
+        int totalSuccess = successCounts.values().stream().mapToInt(AtomicInteger::get).sum();
+        int totalFailures = failureCounts.values().stream().mapToInt(AtomicInteger::get).sum();
+        int totalAttempts = totalCounts.values().stream().mapToInt(AtomicInteger::get).sum();
+        
+        log.info("일일 이메일 발송 통계:");
+        successCounts.keySet().forEach(category -> {
+            log.info("  - {}: 시도={}, 성공={}, 실패={}",
+                    category,
+                    totalCounts.get(category).get(),
+                    successCounts.get(category).get(),
+                    failureCounts.get(category).get());
+        });
+        
+        log.info("총계: 시도={}, 성공={}, 실패={}, 성공률={}%",
+                totalAttempts, totalSuccess, totalFailures,
+                totalAttempts > 0 ? (totalSuccess * 100 / totalAttempts) : 0);
+
+        successCounts.clear();
+        failureCounts.clear();
+        totalCounts.clear();
+    }
+}

--- a/src/main/java/quartet/server/core/code/MailErrorCode.java
+++ b/src/main/java/quartet/server/core/code/MailErrorCode.java
@@ -10,7 +10,7 @@ public enum MailErrorCode implements ResponseCode {
     MAILING_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 메일 구독입니다."),
     MAILING_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 구독 중인 자격증입니다."),
     CERTIFICATION_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND,"자격증의 일정 정보를 찾을 수 없습니다."),
-    MAIL_SENDING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다.");
+    EMAIL_SENDING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/quartet/server/core/config/MailConfig.java
+++ b/src/main/java/quartet/server/core/config/MailConfig.java
@@ -1,0 +1,51 @@
+package quartet.server.core.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth:true}")
+    private String auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable:true}")
+    private String starttls;
+
+    @Value("${spring.mail.debug:false}")
+    private String debug;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", auth);
+        props.put("mail.smtp.starttls.enable", starttls);
+        props.put("mail.debug", debug);
+
+        return mailSender;
+    }
+}

--- a/src/main/java/quartet/server/core/config/ThymeleafConfig.java
+++ b/src/main/java/quartet/server/core/config/ThymeleafConfig.java
@@ -1,0 +1,34 @@
+package quartet.server.core.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+import org.thymeleaf.templateresolver.ITemplateResolver;
+
+import java.nio.charset.StandardCharsets;
+
+@Configuration
+public class ThymeleafConfig {
+
+    @Bean
+    public ITemplateResolver emailTemplateResolver() {
+        ClassLoaderTemplateResolver templateResolver = new ClassLoaderTemplateResolver();
+        templateResolver.setPrefix("templates/");
+        templateResolver.setSuffix(".html");
+        templateResolver.setTemplateMode(TemplateMode.HTML);
+        templateResolver.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        templateResolver.setCacheable(false); // 개발 시에는 false, 운영 시에는 true로 설정 // todo 삭제
+        templateResolver.setOrder(1);
+        return templateResolver;
+    }
+
+    @Bean
+    public TemplateEngine emailTemplateEngine() {
+        SpringTemplateEngine templateEngine = new SpringTemplateEngine();
+        templateEngine.addTemplateResolver(emailTemplateResolver());
+        return templateEngine;
+    }
+}

--- a/src/main/java/quartet/server/core/exception/BaseException.java
+++ b/src/main/java/quartet/server/core/exception/BaseException.java
@@ -12,4 +12,9 @@ public abstract class BaseException extends RuntimeException {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
+
+    protected BaseException(final ResponseCode errorCode, final Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/quartet/server/core/utils/DateUtils.java
+++ b/src/main/java/quartet/server/core/utils/DateUtils.java
@@ -8,26 +8,27 @@ import java.time.temporal.TemporalAdjusters;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class DateUtils {
+    private static final ZoneId TIME_ZONE = ZoneId.systemDefault();
 
     public static Instant now() {
-        return ZonedDateTime.now(ZoneId.systemDefault()).toInstant();
+        return ZonedDateTime.now(TIME_ZONE).toInstant();
     }
 
     public static LocalDate today() {
-        return LocalDate.now(ZoneId.systemDefault());
+        return LocalDate.now(TIME_ZONE);
     }
 
     public static Instant toInstant(final LocalDate date) {
-        return date.atStartOfDay(ZoneId.systemDefault()).toInstant();
+        return date.atStartOfDay(TIME_ZONE).toInstant();
     }
 
     public static LocalDate toLocalDate(final Instant instant) {
-        return LocalDate.ofInstant(instant, ZoneId.systemDefault());
+        return LocalDate.ofInstant(instant, TIME_ZONE);
     }
 
     public static Instant toInstant(final LocalDate date, final int hour, final int minute, final int second) {
         return LocalDateTime.of(date, LocalTime.of(hour, minute, second))
-                .atZone(ZoneId.systemDefault())
+                .atZone(TIME_ZONE)
                 .toInstant();
     }
 
@@ -59,6 +60,18 @@ public final class DateUtils {
     public static Instant getTodayStart() {
         return today()
                 .atStartOfDay(ZoneId.systemDefault())
+                .toInstant();
+    }
+    public static Instant getDayStart(final Instant instant) {
+        return toLocalDate(instant)
+                .atStartOfDay(TIME_ZONE)
+                .toInstant();
+    }
+
+    public static Instant getDayEnd(final Instant instant) {
+        return toLocalDate(instant)
+                .atTime(LocalTime.MAX)
+                .atZone(TIME_ZONE)
                 .toInstant();
     }
 

--- a/src/main/java/quartet/server/domain/mail/exception/EmailSendingFailedException.java
+++ b/src/main/java/quartet/server/domain/mail/exception/EmailSendingFailedException.java
@@ -1,0 +1,9 @@
+package quartet.server.domain.mail.exception;
+
+import quartet.server.core.code.MailErrorCode;
+
+public class EmailSendingFailedException extends MailException {
+    public EmailSendingFailedException(Throwable cause) {
+        super(MailErrorCode.EMAIL_SENDING_FAILED, cause);
+    }
+}

--- a/src/main/java/quartet/server/domain/mail/exception/MailException.java
+++ b/src/main/java/quartet/server/domain/mail/exception/MailException.java
@@ -7,4 +7,9 @@ public class MailException extends BaseException {
     public MailException(final ResponseCode errorCode) {
         super(errorCode);
     }
+
+    public MailException(final ResponseCode errorCode, final Throwable cause) {
+        super(errorCode);
+        initCause(cause);
+    }
 }

--- a/src/main/resources/application-develop.yml
+++ b/src/main/resources/application-develop.yml
@@ -91,6 +91,25 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+    debug: true
+
+  thymeleaf:
+    prefix: classpath:/templates/
+    suffix: .html
+    mode: HTML
+    encoding: UTF-8
+    cache: true
 
 management:
   endpoints:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,18 +19,33 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: update
+    defer-datasource-initialization: true
     properties:
       hibernate:
         format-sql: true
-        dialect: org.hibernate.dialect.MySQL8Dialect
+        dialect: org.hibernate.dialect.MySQLDialect
+        generate_statistics: true # 쿼리 횟수, 캐시 여부 확인
 
-  logging:
-    level:
-      org:
-        springframework:
-          web: DEBUG
-      hibernate:
-        type: TRACE
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+    debug: true
+
+  thymeleaf:
+    prefix: classpath:/templates/
+    suffix: .html
+    mode: HTML
+    encoding: UTF-8
+    cache: false
+
   web:
     resources:
       add-mappings: false
@@ -85,6 +100,16 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
+
+logging:
+  level:
+    org:
+      springframework:
+        web: DEBUG
+    hibernate:
+      type: TRACE
+    springframework:
+      security: DEBUG
 
 management:
   endpoints:

--- a/src/main/resources/templates/email/exam-day.html
+++ b/src/main/resources/templates/email/exam-day.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>시험 안내</title>
+</head>
+<body>
+<div style="padding: 20px; font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', '맑은 고딕', sans-serif;">
+    <div style="max-width: 600px; margin: 0 auto; background-color: #ffffff; padding: 20px; border-radius: 5px; box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);">
+        <div style="font-size: 24px; font-weight: bold; margin-bottom: 20px; color: #333;">자격저격</div>
+        <div style="background-color: #f2f2f2; padding: 15px; border-radius: 4px; margin-bottom: 20px;">
+            <div style="font-weight: bold;"><span th:text="${userName}">이예은</span>님,</div>
+            <div>
+                <span th:text="${dDay}">3</span>일 후에는 <span th:text="${examName}">정보처리기사</span> 시험일입니다.</div>
+        </div>
+        <div style="line-height: 1.6; margin-bottom: 20px;">
+            <span th:text="${userName}">이예은</span>님 안녕하세요,
+            <span th:text="${examName}">정보처리기사</span> 시험이 3일 후로 다가왔습니다.
+            시험을 위한 마무리 준비 시간입니다.
+            지금까지 준비해온 것들을 시험장에서 모두 발휘하시길 바랍니다.
+            시험 전 챙기셔야 하는 것들까지 자격저격이 상세하게 안내해드릴게요!
+        </div>
+        <div style="margin-top: 30px; display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap;">
+            <div style="font-weight: bold; color: #4285f4;">
+                시험일: <span th:text="${examDate}">2025.03.12</span> (<span th:text="${dDay == '0' ? '오늘 시작' : 'D-' + dDay}">D-7</span>)
+            </div>
+            <a th:href="${detailLink}" style="display: inline-block; background-color: #4285f4; color: white; text-decoration: none; padding: 10px 20px; border-radius: 4px; font-weight: bold; text-align: center; border: none; cursor: pointer;">자격증 상세 정보 보기</a>
+        </div>
+
+        <div style="text-align: center; margin-top: 30px; color: #777; font-size: 14px;">
+            <p>이 메일은 발신 전용이며, 회신하실 수 없습니다.</p>
+            <p>메일 수신을 원치 않으시면 자격저격 웹사이트에서 설정을 변경해주세요.</p>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/email/receipt-day.html
+++ b/src/main/resources/templates/email/receipt-day.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>접수 안내</title>
+</head>
+<body>
+<div style="padding: 20px; font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', '맑은 고딕', sans-serif;">
+    <div style="max-width: 600px; margin: 0 auto; background-color: #ffffff; padding: 20px; border-radius: 5px; box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);">
+        <div style="font-size: 24px; font-weight: bold; margin-bottom: 20px; color: #333;">자격저격</div>
+        <div style="background-color: #f2f2f2; padding: 15px; border-radius: 4px; margin-bottom: 20px;">
+            <div style="font-weight: bold;">자격저격 알림</div>
+            <div>다가오는 자격증 접수 안내입니다.</div>
+        </div>
+        <div style="line-height: 1.6; margin-bottom: 20px;">
+            <span th:text="${userName}">이예은</span>님 안녕하세요,
+            <br/>
+            <span th:if="${dDay == '0'}">
+                오늘 아래 자격증들의 접수가 시작되었습니다.
+            </span>
+            <span th:unless="${dDay == '0'}">
+                다가오는 자격증 접수 일정을 안내해 드립니다.
+                <br/>
+                아래 자격증들의 접수 일정이 <strong th:text="${dDay}">D-7</strong>일 남았습니다.
+            </span>
+        </div>
+        <!-- 자격증 목록 반복 -->
+        <div th:each="cert : ${certifications}" style="margin-bottom: 30px; padding: 15px; border: 1px solid #e0e0e0; border-radius: 5px;">
+            <div style="font-weight: bold; font-size: 18px; margin-bottom: 10px;" th:text="${cert.certificationName}">정보처리기사</div>
+            <div style="margin-bottom: 10px;">
+                접수기간: <span th:text="${cert.applicationDate}">2025.03.11</span> (<span th:text="${dDay == '0' ? '오늘 시작' : 'D-' + dDay}">D-7</span>)
+            </div>
+            <div style="display: flex; justify-content: space-between; flex-wrap: wrap; margin-top: 15px;">
+                <a th:href="${cert.detailLink}" style="display: inline-block; background-color: #4285f4; color: white; text-decoration: none; padding: 10px 20px; border-radius: 4px; font-weight: bold; text-align: center; margin-right: 10px; margin-bottom: 10px;">시험 정보 보기</a>
+                <a th:href="${cert.applicationUrl}" style="display: inline-block; background-color: #ff5722; color: white; text-decoration: none; padding: 10px 20px; border-radius: 4px; font-weight: bold; text-align: center; margin-bottom: 10px;">접수하러 가기</a>
+            </div>
+        </div>
+
+        <div style="text-align: center; margin-top: 30px; color: #777; font-size: 14px;">
+            <p>이 메일은 발신 전용이며, 회신하실 수 없습니다.</p>
+            <p>메일 수신을 원치 않으시면 자격저격 웹사이트에서 설정을 변경해주세요.</p>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## ✨관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#85 

## 📍 주요 변경 사항
<!-- 변화한 내용을 적어주세요. 어떻게 수정했는지 설명해주세요. -->
- 아침 8시에 메일을 발송하도록 이메일 전송 로직을 구현했습니다.
- 로깅에 대한 관심사를 분리하기 위해 Spring AOP를 도입해서 이메일 전송 로깅 처리를 했습니다.
- EmailTestController에 이메일 테스트를 위한 API를 만들어 놓았습니다. 이후 삭제할 예정입니다.

테스트 코드는 추후에 보강하도록 하겠습니다! 더불어 이메일 계정도 도메인이 결정된 이후에 도메인에 맞게 바꿀 예정입니다.

## 📝 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성
- [ ] 변경 사항에 대한 테스트 코드를 작성
- [ ] 코드 리뷰를 진행

## To Reviewer
AWS에 환경변수 업데이트 해놓았으니, 확인하시고 문제 없으면 바로 머지 부탁드립니다.