### PR TITLE
자격증 상세 일정 데이터 응답 형식 변경

### DIFF
--- a/src/main/java/quartet/server/api/certification/dto/response/CertificationResponse.java
+++ b/src/main/java/quartet/server/api/certification/dto/response/CertificationResponse.java
@@ -62,23 +62,58 @@ public record CertificationResponse(
         }
     }
 
-    public record CertificationScheduleResponse(
+    public record CertificationScheduleTemp(
             String scheduleType,
             ExamType examType,
             String examRound,
-            List<Instant> date
+            List<Instant> dates
     ){
         @QueryProjection
-        public CertificationScheduleResponse(
+        public CertificationScheduleTemp(
                 String scheduleType,
                 ExamType examType,
                 String examRound,
-                List<Instant> date
+                List<Instant> dates
         ){
             this.scheduleType = scheduleType;
             this.examType = examType;
             this.examRound = examRound;
-            this.date = date;
+            this.dates = dates;
+        }
+
+        public String getExamType() {
+            return examType != null ? examType.getValue() : null;
+        }
+    }
+
+    public record CertificationScheduleResponse(
+            String examRound,
+            List<ScheduleDetailResponse> scheduleDetails
+    ) {
+        @QueryProjection
+        public CertificationScheduleResponse(
+                String examRound,
+                List<ScheduleDetailResponse> scheduleDetails
+        ) {
+            this.examRound = examRound;
+            this.scheduleDetails = scheduleDetails;
+        }
+    }
+
+    public record ScheduleDetailResponse(
+            String scheduleType,
+            ExamType examType,
+            List<Instant> dates
+    ) {
+        @QueryProjection
+        public ScheduleDetailResponse(
+                String scheduleType,
+                ExamType examType,
+                List<Instant> dates
+        ) {
+            this.scheduleType = scheduleType;
+            this.examType = examType;
+            this.dates = dates;
         }
 
         public String getExamType() {

--- a/src/main/java/quartet/server/api/certification/query/CertificationQueryRepository.java
+++ b/src/main/java/quartet/server/api/certification/query/CertificationQueryRepository.java
@@ -135,10 +135,35 @@ public class CertificationQueryRepository {
         ));
     }
 
-    private List<CertificationResponse.CertificationScheduleResponse> getScheduleDetails(final long certificationId) {
+    private  List<CertificationResponse.CertificationScheduleResponse> getScheduleDetails(final long certificationId) {
+
+        List<CertificationResponse.CertificationScheduleTemp> temp = getScheduleTemp(certificationId);
+
+        HashMap<String, List<CertificationResponse.ScheduleDetailResponse>> result = new HashMap<>();
+
+        for (CertificationResponse.CertificationScheduleTemp x: temp){
+            String examRound = x.examRound();
+            List<CertificationResponse.ScheduleDetailResponse> details = result.computeIfAbsent(examRound,k -> new ArrayList<>());
+            details.add(new CertificationResponse.ScheduleDetailResponse(
+                    x.scheduleType(),
+                    x.examType(),
+                    x.dates()
+            ));
+        }
+
+        List<CertificationResponse.CertificationScheduleResponse> response = new ArrayList<>();
+        for (HashMap.Entry<String, List<CertificationResponse.ScheduleDetailResponse>> x: result.entrySet()){
+            response.add(new CertificationResponse.CertificationScheduleResponse(
+                    x.getKey(),
+                    x.getValue()
+            ));
+        }
+        return response;
+    }
+    private List<CertificationResponse.CertificationScheduleTemp> getScheduleTemp(final long certificationId) {
         QCertificationSchedule schedule = QCertificationSchedule.certificationSchedule;
-        
-        // 일정 정보는 현재 연도 기준만 가져옵니다
+
+        // 일정 정보는 현재 연도 기준만 조회
         int currentYear = Instant.now().atZone(java.time.ZoneId.systemDefault()).getYear();
         Instant startOfYear = Instant.parse(currentYear + "-01-01T00:00:00Z");
         Instant endOfYear = Instant.parse(currentYear + "-12-31T23:59:59Z");
@@ -164,7 +189,7 @@ public class CertificationQueryRepository {
                 schedule.examType,
                 scheduleTypeExpression
             ).list(
-                new QCertificationResponse_CertificationScheduleResponse(
+                new QCertificationResponse_CertificationScheduleTemp(
                     scheduleTypeExpression,
                     schedule.examType,
                     schedule.examRound,

--- a/src/test/java/quartet/server/utils/fixture/Certification/CertificationFixture.java
+++ b/src/test/java/quartet/server/utils/fixture/Certification/CertificationFixture.java
@@ -3,39 +3,40 @@ package quartet.server.utils.fixture.Certification;
 import quartet.server.api.certification.dto.response.CertificationResponse;
 import quartet.server.api.certification.dto.response.CertificationsByCategoryResponse;
 import quartet.server.domain.certification.type.ExamType;
-import quartet.server.domain.certification.type.ScheduleType;
 import quartet.server.domain.certification.type.ProblemType;
-import quartet.server.domain.category.model.MainCategory;
-import quartet.server.domain.category.model.SubCategory;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 public class CertificationFixture {
     public static List<CertificationResponse.CertificationScheduleResponse> certificationScheduleResList() {
-        return List.of(
-            new CertificationResponse.CertificationScheduleResponse(
-                "접수일",
-                ExamType.PRACTICAL,
-                "1회차",
-                List.of(Instant.parse("2025-05-01T09:00:00Z"), Instant.parse("2025-05-02T09:00:00Z"))
-            ),
-            new CertificationResponse.CertificationScheduleResponse(
-                "시험일",
-                ExamType.PRACTICAL,
-                "1회차",
-                List.of(Instant.parse("2025-06-15T14:00:00Z"), Instant.parse("2025-06-16T14:00:00Z"))
-            ),
-            new CertificationResponse.CertificationScheduleResponse(
-                "합격일",
-                ExamType.PRACTICAL,
-                "1회차",
-                List.of(Instant.parse("2025-07-01T09:00:00Z"))
-            )
-        );
+        List<CertificationResponse.CertificationScheduleResponse> roundSchedules = new ArrayList<>();
+        
+        List<CertificationResponse.ScheduleDetailResponse> scheduleDetails = new ArrayList<>();
+        scheduleDetails.add(new CertificationResponse.ScheduleDetailResponse(
+            "접수일",
+            ExamType.PRACTICAL,
+            List.of(Instant.parse("2025-05-01T09:00:00Z"), Instant.parse("2025-05-02T09:00:00Z"))
+        ));
+        scheduleDetails.add(new CertificationResponse.ScheduleDetailResponse(
+            "시험일",
+            ExamType.PRACTICAL,
+            List.of(Instant.parse("2025-06-15T14:00:00Z"), Instant.parse("2025-06-16T14:00:00Z"))
+        ));
+        scheduleDetails.add(new CertificationResponse.ScheduleDetailResponse(
+            "합격일",
+            ExamType.PRACTICAL,
+            List.of(Instant.parse("2025-07-01T09:00:00Z"))
+        ));
+
+        roundSchedules.add(new CertificationResponse.CertificationScheduleResponse(
+            "1회차",
+            scheduleDetails
+        ));
+
+        return roundSchedules;
     }
 
     public static List<CertificationResponse.CertificationExamDetailResponse> certificationExamDetailResList() {


### PR DESCRIPTION
## ✨관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

closed #95 

## 📍 주요 변경 사항
<!-- 변화한 내용을 적어주세요. 어떻게 수정했는지 설명해주세요. -->

화면 작업 과정에서, 기존 데이터 형식은 examRound에 따른 그룹핑이 어려움을 요청주셨습니다. 
examRound에 따라, 일정 정보를 묶어 보내도록  응답 형식을 수정하였습니다. 


** 변경전
```
"schedules": [
            {
                "scheduleType": "접수일",
                "examType": "필기",
                "examRound": "2025년도 135회",
                "date": [
                    "2025-01-06T10:00:00Z",
                    "2025-01-09T18:00:00Z"
                ]
            },
            {
                "scheduleType": "시험일",
                "examType": "필기",
                "examRound": "2025년도 135회",
                "date": [
                    "2025-02-08T09:00:00Z",
                    "2025-02-08T09:00:00Z"
                ]
            }
]
```

** 변경후
```
"schedules": [
            {
                "examRound": "2025년도 135회",
                "scheduleDetails": [
                    {
                        "scheduleType": "접수일",
                        "examType": "필기",
                        "dates": [
                            "2025-01-06T10:00:00Z",
                            "2025-01-09T18:00:00Z"
                        ]
                    },
                    {
                        "scheduleType": "시험일",
                        "examType": "필기",
                        "dates": [
                            "2025-02-08T09:00:00Z",
                            "2025-02-08T09:00:00Z"
                        ]
                    }
             ]
         }
      ]
```


## 📝 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성
- [ ] 변경 사항에 대한 테스트 코드를 작성
- [ ] 코드 리뷰를 진행