### PR TITLE
자격증 상세 페이지 조회수 로직 추가 및 추천 자격증 로직 수정

### DIFF
--- a/src/main/java/quartet/server/api/certification/query/CategoryQueryRepository.java
+++ b/src/main/java/quartet/server/api/certification/query/CategoryQueryRepository.java
@@ -31,7 +31,7 @@ public class CategoryQueryRepository {
 
     public List<Long> findInterestedCategoryIds(final Long memberId) {
         return queryFactory
-                .select(memberCategory.subCategory.id)
+                .select(memberCategory.mainCategory.id)
                 .from(memberCategory)
                 .where(memberCategory.member.id.eq(memberId))
                 .fetch();
@@ -42,7 +42,7 @@ public class CategoryQueryRepository {
                 .select(subCategory.id)
                 .from(subCategory)
                 .join(subCategory.mainCategory, mainCategory)
-                .where(mainCategory.isDefault.eq(true))
+                .where(mainCategory.id.eq(23L))
                 .orderBy(subCategory.id.asc())
                 .limit(1)
                 .fetchOne();

--- a/src/main/java/quartet/server/api/certification/query/CertificationQueryRepository.java
+++ b/src/main/java/quartet/server/api/certification/query/CertificationQueryRepository.java
@@ -4,6 +4,7 @@ import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,12 +12,13 @@ import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 import quartet.server.api.certification.dto.response.*;
 import quartet.server.domain.certification.model.*;
-import quartet.server.domain.certification.type.ExamType;
 import quartet.server.domain.certification.type.QualificationType;
 import quartet.server.domain.certification.type.ScheduleType;
 import quartet.server.domain.category.model.QMainCategory;
 import quartet.server.domain.category.model.QSubCategory;
 import quartet.server.domain.certification.type.TechnicalGradeType;
+import quartet.server.domain.member.model.MemberCategory;
+import quartet.server.domain.member.model.QMemberCategory;
 
 import java.time.Instant;
 import java.util.*;
@@ -206,19 +208,6 @@ public class CertificationQueryRepository {
             .where(certification.subCategory.id.eq(subCategoryId));
     }
 
-
-    public List<CertificationSearchResponse> findAllCertificationByCategory(final long subCategoryId, final int count){
-
-        List<Long> certificationIds =
-                findAllCertificationsByCategoryBaseQuery(subCategoryId)
-                .limit(count)
-                .fetch();
-
-        if (certificationIds.isEmpty()) return List.of();
-
-        return getAllCertificationsByIds(certificationIds);
-    }
-
     public Page<CertificationSearchResponse> findAllCertificationByCategory(final long subCategoryId, final Pageable pageable){
             QCertification certification = QCertification.certification;
 
@@ -236,31 +225,6 @@ public class CertificationQueryRepository {
                                         .select(certification.count());
 
             return PageableExecutionUtils.getPage(certifications, pageable, countQuery::fetchOne);
-    }
-
-    public List<MainCategoryResponse> findAllMainCategories() {
-        QMainCategory mainCategory = QMainCategory.mainCategory;
-        return queryFactory
-                .select(new QMainCategoryResponse(
-                        mainCategory.id,
-                        mainCategory.name,
-                        mainCategory.isDefault
-                ))
-                .from(mainCategory)
-                .fetch();
-    }
-
-    public List<SubCategoryResponse> findAllSubCategoriesByMainCategoryId(final long mainCategoryId) {
-        QSubCategory subCategory = QSubCategory.subCategory;
-        return queryFactory
-                .select(new QSubCategoryResponse(
-                        subCategory.id,
-                        subCategory.name,
-                        subCategory.mainCategory.id
-                ))
-                .from(subCategory)
-                .where(subCategory.mainCategory.id.eq(mainCategoryId))
-                .fetch();
     }
 
     public List<CertificationSearchResponse> getCertificationsBySearch(final String name) {
@@ -321,7 +285,54 @@ public class CertificationQueryRepository {
                         )
                 ));
     }
+
+    public void incrementViewCountWithLock(final long certificationId) {
+        QCertification certification = QCertification.certification;
+        Certification entity = queryFactory
+                .selectFrom(certification)
+                .where(certification.id.eq(certificationId))
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+                .fetchOne();
+        if (entity != null) {
+            entity.incrementViewCount();
+        }
+    }
+
+ 
+    public List<CertificationSearchResponse> getTop6ByViewCount() {
+        QCertification certification = QCertification.certification;
+        List<Long> top6Ids = queryFactory
+                .select(certification.id)
+                .from(certification)
+                .orderBy(certification.viewCount.desc())
+                .limit(6)
+                .fetch();
+        if (top6Ids.isEmpty()) return List.of();
+
+        return getAllCertificationsByIds(top6Ids);
+    }
+
+    public List<Long> findSubCategoryIdsByMainCategoryIds(final List<Long> mainCategoryIds) {
+        QSubCategory subCategory = QSubCategory.subCategory;
+        return queryFactory
+                .select(subCategory.id)
+                .from(subCategory)
+                .where(subCategory.mainCategory.id.in(mainCategoryIds))
+                .fetch();
+    }
+
+
+    public List<CertificationSearchResponse> findTop6BySubCategoryIdsOrderByViewCountDesc(final List<Long> subCategoryIds) {
+        QCertification certification = QCertification.certification;
+
+        List<Long> top6Ids = queryFactory
+                .select(certification.id)
+                .from(certification)
+                .where(certification.subCategory.id.in(subCategoryIds))
+                .orderBy(certification.viewCount.desc())
+                .limit(6)
+                .fetch();
+        if (top6Ids.isEmpty()) return List.of();
+        return getAllCertificationsByIds(top6Ids);
+    }
 }
-
-
-

--- a/src/main/java/quartet/server/api/certification/service/CertificationService.java
+++ b/src/main/java/quartet/server/api/certification/service/CertificationService.java
@@ -18,8 +18,10 @@ import quartet.server.domain.certification.repository.*;
 import quartet.server.domain.certification.exception.CertificationNotFoundException;
 import quartet.server.domain.category.exception.CategoryNotFoundException;
 import quartet.server.domain.category.exception.SubCategoryNotFoundException;
+import quartet.server.domain.member.model.MemberCategory;
 import quartet.server.domain.member.repository.MemberCategoryRepository;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -42,9 +44,22 @@ public class CertificationService {
     private final RandomGenerator randomGenerator;
 
 
+    @Transactional(readOnly = false)
     public CertificationResponse getCertification(final long certificationId) {
-        return certificationQueryRepository.getCertification(certificationId)
-                 .orElseThrow(CertificationNotFoundException::new);
+        // 데이터 조회
+        CertificationResponse response = certificationQueryRepository.getCertification(certificationId)
+                .orElseThrow(CertificationNotFoundException::new);
+        // 조회수 
+        incrementViewCount(certificationId);
+        return response;
+    }
+
+    /**
+     * select for update로 viewCount를 증가시키는 메서드 (별도 트랜잭션, QueryDSL)
+     */
+    @Transactional(propagation = Propagation.REQUIRED)
+    public void incrementViewCount(long certificationId) {
+        certificationQueryRepository.incrementViewCountWithLock(certificationId);
     }
 
     public Page<CertificationSearchResponse> getAllCertificationsByCategory(
@@ -89,10 +104,8 @@ public class CertificationService {
     }
 
     public Long getRecommendedCategoryId(final Long memberId) {
-        if (memberId == null) return categoryQueryRepository.getDefaultRecommendedCategoryId();
-
         List<Long> interestedCategoryIds = categoryQueryRepository.findInterestedCategoryIds(memberId);
-        if (interestedCategoryIds.isEmpty()) return categoryQueryRepository.getDefaultRecommendedCategoryId();
+
         if (interestedCategoryIds.size() == 1) return interestedCategoryIds.getFirst();
 
         Long randomItem = randomGenerator.getRandomItem(interestedCategoryIds);
@@ -101,8 +114,21 @@ public class CertificationService {
     }
 
     public List<CertificationSearchResponse> getRecommendedCertifications(final Long memberId) {
-        long categoryId = getRecommendedCategoryId(memberId);
-        return certificationQueryRepository.findAllCertificationByCategory(categoryId, 6);
+        // 관심 카테고리가 없는 경우 - 조회수 상위 6개 반환
+        if (memberId == null) return certificationQueryRepository.getTop6ByViewCount();
+
+        List<MemberCategory> interestedMainCategories = memberCategoryRepository.findByMemberId(memberId);
+
+        if (interestedMainCategories.isEmpty()) return certificationQueryRepository.getTop6ByViewCount();
+        else {
+            List<Long> mainCategoryIds = new ArrayList<>();
+            for (MemberCategory x: interestedMainCategories){
+                mainCategoryIds.add(x.getMainCategory().getId());
+            }
+            List<Long> subCategoryIds = certificationQueryRepository.findSubCategoryIdsByMainCategoryIds(mainCategoryIds);
+            return certificationQueryRepository.findTop6BySubCategoryIdsOrderByViewCountDesc(subCategoryIds);
+
+        }
     }
 
     public List<CertificationSearchResponse> getCertificationsBySearch(final String name) {

--- a/src/test/java/quartet/server/api/calendar/fixture/CalendarFixture.java
+++ b/src/test/java/quartet/server/api/calendar/fixture/CalendarFixture.java
@@ -57,7 +57,7 @@ public class CalendarFixture {
                         List.of(
                                 CalendarResponse.CalendarScheduleResponse.of(
                                         ScheduleGroup.APPLICATION.getValue(),
-                                        ExamType.WRITTEN.getValue(),
+                                        ExamType.WRITTEN,
                                         "1회",
                                         List.of(
                                                 Instant.parse("2024-01-15T00:00:00Z"),
@@ -67,7 +67,7 @@ public class CalendarFixture {
                                 ),
                                 CalendarResponse.CalendarScheduleResponse.of(
                                         ScheduleGroup.EXAM.getValue(),
-                                        ExamType.WRITTEN.getValue(),
+                                        ExamType.WRITTEN,
                                         "1회",
                                         List.of(
                                                 Instant.parse("2024-03-01T00:00:00Z"),
@@ -77,7 +77,7 @@ public class CalendarFixture {
                                 ),
                                 CalendarResponse.CalendarScheduleResponse.of(
                                         ScheduleGroup.PASS.getValue(),
-                                        ExamType.WRITTEN.getValue(),
+                                        ExamType.WRITTEN,
                                         "1회",
                                         List.of(
                                                 Instant.parse("2024-04-09T00:00:00Z"),

--- a/src/test/java/quartet/server/api/certification/service/CertificationServiceTest.java
+++ b/src/test/java/quartet/server/api/certification/service/CertificationServiceTest.java
@@ -338,27 +338,39 @@ class CertificationServiceTest {
 
     @Nested
     class getRecommendedCertifications {
+
         @Test
-        @DisplayName("관심 카테고리가 있는 로그인 유저에게, 관심 분야에 대한 추천 자격증을 조회한다")
-        public void success() {
+        @DisplayName("비회원의 경우, 조회수 상위 최대 6개 데이터를 추천한다")
+        void success_whenNonUserRecommendation(){
             // given
-            final long memberId = 1L;
-            final long categoryId = 1L;
-            final List<CertificationSearchResponse> certificationList = List.of(
-                new CertificationSearchResponse(1L, "IT", "데이터베이스", "자격증 1", Instant.parse("2025-05-01T09:00:00Z"), Instant.parse("2025-05-01T10:00:00Z"), 100),
-                new CertificationSearchResponse(2L, "IT", "프로그래밍", "자격증 2", Instant.parse("2025-05-01T08:00:00Z"), Instant.parse("2025-05-01T10:00:00Z"), 50)
-            );
-            doReturn(categoryId).when(certificationService).getRecommendedCategoryId(memberId);
-            when(certificationQueryRepository.findAllCertificationByCategory(categoryId, 6))
-                    .thenReturn(certificationList);
+            final Long memberId = null;
+            List<CertificationSearchResponse> expected = CertificationFixture.certificationSearchResponseList();
+            when(certificationQueryRepository.getTop6ByViewCount()).thenReturn(expected);
 
             // when
-            final List<CertificationSearchResponse> result = certificationService.getRecommendedCertifications(memberId);
+            List<CertificationSearchResponse> result = certificationService.getRecommendedCertifications(memberId);
 
             // then
-            assertThat(result).isEqualTo(certificationList);
-            verify(certificationService, times(1)).getRecommendedCategoryId(memberId);
-            verify(certificationQueryRepository, times(1)).findAllCertificationByCategory(categoryId, 6);
+            assertThat(result).isEqualTo(CertificationFixture.certificationSearchResponseList());
+            verify(certificationQueryRepository).getTop6ByViewCount();
+        }
+
+        @Test
+        @DisplayName("관심 카테고리가 없는 경우 조회수 상위 최대 6개 데이터를 추천한다")
+        void success_whenNoInterestedCategories() {
+            // given
+            final long memberId = 1L;
+            List<CertificationSearchResponse> expected = CertificationFixture.certificationSearchResponseList();
+            when(memberCategoryRepository.findByMemberId(memberId)).thenReturn(List.of());
+            when(certificationQueryRepository.getTop6ByViewCount()).thenReturn(expected);
+
+            // when
+            List<CertificationSearchResponse> result = certificationService.getRecommendedCertifications(memberId);
+
+            // then
+            assertThat(result).isEqualTo(expected);
+            verify(memberCategoryRepository.findByMemberId(memberId));
+            verify(certificationQueryRepository).getTop6ByViewCount();
         }
     }
 } 

--- a/src/test/java/quartet/server/utils/fixture/Certification/CertificationFixture.java
+++ b/src/test/java/quartet/server/utils/fixture/Certification/CertificationFixture.java
@@ -1,6 +1,7 @@
 package quartet.server.utils.fixture.Certification;
 
 import quartet.server.api.certification.dto.response.CertificationResponse;
+import quartet.server.api.certification.dto.response.CertificationSearchResponse;
 import quartet.server.api.certification.dto.response.CertificationsByCategoryResponse;
 import quartet.server.domain.certification.type.ExamType;
 import quartet.server.domain.certification.type.ProblemType;
@@ -128,6 +129,13 @@ public class CertificationFixture {
                 )
             )),
             certificationScheduleResList()
+        );
+    }
+
+    public static List<CertificationSearchResponse> certificationSearchResponseList() {
+        return List.of(
+            new CertificationSearchResponse(1L, "IT", "DB", "자격증1", (Instant) null, null, 0),
+            new CertificationSearchResponse(2L, "IT", "프로그래밍", "자격증2", (Instant) null, null, 0)
         );
     }
 }


### PR DESCRIPTION
## ✨관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#99 

## 📍 주요 변경 사항
1. 자격증 상세 조회 시 조회수 증가 로직 추가
2. 추천 자격증 조회 로직 전면 리팩토링
    - 비회원/관심 카테고리 없는 회원: 전체 자격증 중 viewCount(조회수) 기준 상위 6개를 추천합니다.
    - 관심 카테고리가 있는 회원:
       1) 회원의 관심 대분류(MainCategory) id를 모두 조회
       2) 해당 대분류에 속한 모든 소분류(SubCategory) id를 조회
       3) 이 소분류에 속한 자격증 중 viewCount(조회수) 상위 최대 6개를 추출
       4) 해당 자격증의 상세 정보를 join하여 추천 결과로 반환

## 📝 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성
- [x] 변경 사항에 대한 테스트 코드를 작성
- [ ] 코드 리뷰를 진행