### PR TITLE
Security Config 설정 변경

### DIFF
--- a/src/main/java/quartet/server/core/config/SecurityConfig.java
+++ b/src/main/java/quartet/server/core/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -65,15 +66,15 @@ public class SecurityConfig {
                                 .userService(customOAuth2UserService)) // OAuth2 로그인 설정
                         .successHandler(oauthLoginSuccessHandler))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/","/actuator/health", "/login", "/logout", "/api/v1/oauth2-jwt-header", "/api/v1/reissue",
-                                "/api/v1/certifications/**"
+                        .requestMatchers(HttpMethod.GET, "/api/v1/certifications/**").permitAll()
+                        .requestMatchers("/","/actuator/health", "/login", "/logout", "/api/v1/oauth2-jwt-header", "/api/v1/reissue"
 //                                , "/v3/api-docs/**"  // OpenAPI 3 문서 엔드포인트
 //                                "/swagger-ui/**",
 //                                "/swagger-ui.html",
 //                                "/swagger-resources/**",
 //                                "/webjars/**",
 //                                "/swagger-ui/index.html"
-                                ).permitAll() // TODO: 나중에 더 추가, 스웨거 삭제
+                                ).permitAll()
                         .anyRequest().authenticated() // 그 외 모든 요청은 인증 필요
                 )
                 .logout(AbstractHttpConfigurer::disable) // 기본 로그아웃 비활성화


### PR DESCRIPTION
## ✨관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#114 

## 📍 주요 변경 사항
<!-- 변화한 내용을 적어주세요. 어떻게 수정했는지 설명해주세요. -->
SecurityConfig에 /api/v1/certifications/**가 모든 http 메서드에 대해 로그인 인증을 하지 않아도 되도록 설정되어 있었는데, 해당 엔드포인트 형식을 메일링 구독 api에서도 post 요청으로 사용하고 있었습니다.
따라서 기대한 바와 같이 인증 처리가 되지 않았고, 이를 해결하기 위해서 /api/v1/certifications/** + get 조합만 인가 처리를 거치지 않을 수 있도록 수정했습니다.

## 📝 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성
- [ ] 변경 사항에 대한 테스트 코드를 작성
- [ ] 코드 리뷰를 진행