### PR TITLE
🎯 Fix: 카테고리별 자격증 조회 버그 해결

### DIFF
--- a/src/main/java/quartet/server/api/certification/controller/CertificationController.java
+++ b/src/main/java/quartet/server/api/certification/controller/CertificationController.java
@@ -51,13 +51,14 @@ public class CertificationController {
     // 특정 카테고리 자격증 조회
     @GetMapping("")
     public ApiResponse<Page<CertificationSearchResponse>> getAllCertificationByCategory(
+            @RequestParam boolean isMain,
             @RequestParam long categoryId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "15") int pageSize
     ) {
         PageRequest pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Order.asc("id")));
         Page<CertificationSearchResponse> certifications = certificationService.getAllCertificationsByCategory(
-                categoryId, pageable);
+                isMain, categoryId, pageable);
         return ApiResponse.success(OK, certifications);
     }
 

--- a/src/main/java/quartet/server/api/certification/query/CategoryQueryRepository.java
+++ b/src/main/java/quartet/server/api/certification/query/CategoryQueryRepository.java
@@ -24,7 +24,7 @@ public class CategoryQueryRepository {
                 .fetchFirst());
     }
 
-    public List<Long> findInterestedCategoryIds(final Long memberId) {
+    public List<Long> findInterestedCategoryIds(final long memberId) {
         return queryFactory
                 .select(memberCategory.mainCategory.id)
                 .from(memberCategory)

--- a/src/main/java/quartet/server/api/certification/query/CategoryQueryRepository.java
+++ b/src/main/java/quartet/server/api/certification/query/CategoryQueryRepository.java
@@ -21,9 +21,7 @@ public class CategoryQueryRepository {
                 .select(subCategory.id)
                 .from(subCategory)
                 .where(subCategory.mainCategory.id.eq(mainCategoryId))
-                .orderBy(subCategory.id.asc())
-                .limit(1)
-                .fetchOne());
+                .fetchFirst());
     }
 
     public List<Long> findInterestedCategoryIds(final Long memberId) {

--- a/src/main/java/quartet/server/api/certification/query/CertificationQueryRepository.java
+++ b/src/main/java/quartet/server/api/certification/query/CertificationQueryRepository.java
@@ -17,8 +17,6 @@ import quartet.server.domain.certification.type.ScheduleType;
 import quartet.server.domain.category.model.QMainCategory;
 import quartet.server.domain.category.model.QSubCategory;
 import quartet.server.domain.certification.type.TechnicalGradeType;
-import quartet.server.domain.member.model.MemberCategory;
-import quartet.server.domain.member.model.QMemberCategory;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;

--- a/src/main/java/quartet/server/api/certification/service/CertificationService.java
+++ b/src/main/java/quartet/server/api/certification/service/CertificationService.java
@@ -55,12 +55,12 @@ public class CertificationService {
     }
 
     @Transactional(propagation = Propagation.REQUIRED)
-    public void incrementViewCount(long certificationId) {
+    public void incrementViewCount(final long certificationId) {
         certificationQueryRepository.incrementViewCountWithLock(certificationId);
     }
 
     public Page<CertificationSearchResponse> getAllCertificationsByCategory(
-            boolean isMain, long categoryId, final Pageable pageable) {
+            final boolean isMain, final long categoryId, final Pageable pageable) {
         Long subCategoryId;
         if (isMain)  {
             subCategoryId = categoryQueryRepository.getDefaultSubCategoryId(categoryId)

--- a/src/main/java/quartet/server/api/certification/service/CertificationService.java
+++ b/src/main/java/quartet/server/api/certification/service/CertificationService.java
@@ -60,11 +60,15 @@ public class CertificationService {
     }
 
     public Page<CertificationSearchResponse> getAllCertificationsByCategory(
-            long categoryId, final Pageable pageable) {
-        SubCategory subCategory = subCategoryRepository.findById(categoryId)
-                .orElseThrow(SubCategoryNotFoundException::new);
-
-        return certificationQueryRepository.findAllCertificationByCategory(categoryId, pageable);
+            boolean isMain, long categoryId, final Pageable pageable) {
+        Long subCategoryId;
+        if (isMain)  {
+            subCategoryId = categoryQueryRepository.getDefaultSubCategoryId(categoryId)
+                            .orElseThrow(SubCategoryNotFoundException::new);
+        }
+        else subCategoryId = categoryId;
+        System.out.println(subCategoryId);
+        return certificationQueryRepository.findAllCertificationByCategory(subCategoryId, pageable);
     }
 
     public List<CertificationCategoriesResponse> getCategories(final boolean isDefault) {

--- a/src/test/java/quartet/server/api/certification/controller/CertificationControllerTest.java
+++ b/src/test/java/quartet/server/api/certification/controller/CertificationControllerTest.java
@@ -129,6 +129,7 @@ public class CertificationControllerTest {
     @DisplayName("특정 자격증 카테고리에 속하는 자격증들을 조회한다")
     void success_getAllCertificationByCategoryTest() throws Exception {
         // given
+        final boolean isMain = false;
         final long categoryId = 1L;
         final Pageable pageable = PageableFixture.pageable(0,10, Sort.by(Sort.Order.asc("id")));
         final List<CertificationSearchResponse> certificationList = List.of(
@@ -139,9 +140,7 @@ public class CertificationControllerTest {
         final ApiResponse<Page<CertificationSearchResponse>> expectedResponse = ApiResponse.success(
                 CommonSuccessCode.OK, responses);
 
-        when(certificationService.getAllCertificationsByCategory(
-                eq(categoryId), eq(pageable)
-        )).thenReturn(responses);
+        when(certificationService.getAllCertificationsByCategory(eq(isMain), eq(categoryId), eq(pageable))).thenReturn(responses);
 
         // when
         final String result = mockMvc.perform(
@@ -158,7 +157,7 @@ public class CertificationControllerTest {
         // then
         final String expectedJson = objectMapper.writeValueAsString(expectedResponse);
         assertThat(result).isEqualTo(expectedJson);
-        verify(certificationService, times(1)).getAllCertificationsByCategory(categoryId,pageable);
+        verify(certificationService, times(1)).getAllCertificationsByCategory(isMain, categoryId,pageable);
     }
 
     @Test

--- a/src/test/java/quartet/server/api/certification/service/CertificationServiceTest.java
+++ b/src/test/java/quartet/server/api/certification/service/CertificationServiceTest.java
@@ -192,7 +192,7 @@ class CertificationServiceTest {
 
             // when
             Page<CertificationSearchResponse> result = certificationService.getAllCertificationsByCategory(
-                    subCategoryId, pageable);
+                    false, subCategoryId, pageable);
 
             // then
             assertThat(result).isEqualTo(certificationPage);
@@ -208,7 +208,7 @@ class CertificationServiceTest {
             when(subCategoryRepository.findById(subCategoryId)).thenReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> certificationService.getAllCertificationsByCategory(subCategoryId, pageable))
+            assertThatThrownBy(() -> certificationService.getAllCertificationsByCategory(false, subCategoryId, pageable))
                     .isInstanceOf(SubCategoryNotFoundException.class);
             verify(certificationQueryRepository, never()).findAllCertificationByCategory(subCategoryId, pageable);
         }


### PR DESCRIPTION
## ✨관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #123 

## 📍 주요 변경 사항
<!-- 변화한 내용을 적어주세요. 어떻게 수정했는지 설명해주세요. -->
메인페이지에서 대분류 카테고리를 눌러서, 자격증 조회를 할 경우 발생하는 버그를 수정하였습니다.
(대분류 카테고리로 자격증 조회 요청을 할 경우, 디폴트 소분류 id값을 먼저 조회한 후 해당되는 자격증을 반환하도록 수정)

## 📝 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성
- [ ] 변경 사항에 대한 테스트 코드를 작성
- [ ] 코드 리뷰를 진행